### PR TITLE
Add compressing transition style to indicator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ public struct Indicator {
 	public var isProgressive: Bool?
 	/// Whether the indicator bounces at the end of page ranges.
 	public var bounces: Bool?
+	/// Whether the indicator compresses at the end of page ranges.
+	public var compresses: Bool?
 	/// Whether to use rounded corners on line indicators.
 	public var useRoundedCorners: Bool?
 }

--- a/Sources/Tabman/TabmanBar/TabmanBar+Appearance.swift
+++ b/Sources/Tabman/TabmanBar/TabmanBar+Appearance.swift
@@ -117,8 +117,8 @@ public extension TabmanBar {
         private func setDefaultValues() {
             
             // indicator
-            self.indicator.bounces = false
-            self.indicator.compresses = true
+            self.indicator.bounces = true
+            self.indicator.compresses = false
             self.indicator.isProgressive = false
             self.indicator.useRoundedCorners = false
             self.indicator.lineWeight = .normal

--- a/Sources/Tabman/TabmanBar/TabmanBar+Appearance.swift
+++ b/Sources/Tabman/TabmanBar/TabmanBar+Appearance.swift
@@ -29,12 +29,14 @@ public extension TabmanBar {
             /// Whether the indicator bounces at the end of page ranges.
             public var bounces: Bool? {
                 didSet {
+                    guard bounces != oldValue else { return }
                     self.compresses = !(bounces ?? defaultAppearance.indicator.bounces!)
                 }
             }
             /// Whether the indicator compresses at the end of page ranges.
             public var compresses: Bool? {
                 didSet {
+                    guard compresses != oldValue else { return }
                     self.bounces = !(compresses ?? defaultAppearance.indicator.compresses!)
                 }
             }
@@ -115,8 +117,8 @@ public extension TabmanBar {
         private func setDefaultValues() {
             
             // indicator
-            self.indicator.bounces = true
-            self.indicator.compresses = false
+            self.indicator.bounces = false
+            self.indicator.compresses = true
             self.indicator.isProgressive = false
             self.indicator.useRoundedCorners = false
             self.indicator.lineWeight = .normal

--- a/Sources/Tabman/TabmanBar/TabmanBar+Appearance.swift
+++ b/Sources/Tabman/TabmanBar/TabmanBar+Appearance.swift
@@ -27,7 +27,17 @@ public extension TabmanBar {
             /// Whether the indicator transiton is progressive.
             public var isProgressive: Bool?
             /// Whether the indicator bounces at the end of page ranges.
-            public var bounces: Bool?
+            public var bounces: Bool? {
+                didSet {
+                    self.compresses = !(bounces ?? defaultAppearance.indicator.bounces!)
+                }
+            }
+            /// Whether the indicator compresses at the end of page ranges.
+            public var compresses: Bool? {
+                didSet {
+                    self.bounces = !(compresses ?? defaultAppearance.indicator.compresses!)
+                }
+            }
             /// Whether to use rounded corners on line indicators.
             public var useRoundedCorners: Bool?
         }
@@ -106,6 +116,7 @@ public extension TabmanBar {
             
             // indicator
             self.indicator.bounces = true
+            self.indicator.compresses = false
             self.indicator.isProgressive = false
             self.indicator.useRoundedCorners = false
             self.indicator.lineWeight = .normal

--- a/Sources/Tabman/TabmanBar/TabmanBar.swift
+++ b/Sources/Tabman/TabmanBar/TabmanBar.swift
@@ -116,6 +116,7 @@ open class TabmanBar: UIView, TabmanBarLifecycle {
         }
     }
     internal var indicatorBounces: Bool = TabmanBar.Appearance.defaultAppearance.indicator.bounces ?? false
+    internal var indicatorCompresses: Bool = TabmanBar.Appearance.defaultAppearance.indicator.compresses ?? false
     internal var indicatorMaskView: UIView = {
         let maskView = UIView()
         maskView.backgroundColor = .black
@@ -300,6 +301,9 @@ open class TabmanBar: UIView, TabmanBarLifecycle {
 
         let indicatorBounces = appearance.indicator.bounces
         self.indicatorBounces = indicatorBounces ?? defaultAppearance.indicator.bounces!
+        
+        let indicatorCompresses = appearance.indicator.compresses ?? defaultAppearance.indicator.compresses!
+        self.indicatorCompresses = indicatorCompresses
         
         let indicatorColor = appearance.indicator.color
         self.indicator?.tintColor = indicatorColor ?? defaultAppearance.indicator.color!

--- a/Sources/Tabman/TabmanBar/Transitioning/IndicatorTransition/TabmanScrollingBarIndicatorTransition.swift
+++ b/Sources/Tabman/TabmanBar/Transitioning/IndicatorTransition/TabmanScrollingBarIndicatorTransition.swift
@@ -72,9 +72,22 @@ internal class TabmanScrollingBarIndicatorTransition: TabmanIndicatorTransition 
             let interpolatedXOrigin = lowerButton.frame.origin.x + xDiff
             bar.indicatorLeftMargin?.constant = interpolatedXOrigin
             
+            let isOutOfBounds = lowerButton === upperButton
+            
+            // compress indicator at boundaries if required
+            if bar.indicatorCompresses && isOutOfBounds {
+                let indicatorWidth = bar.indicatorWidth?.constant ?? 0.0
+                let indicatorDiff = (indicatorWidth * fabs(progress))
+                
+                bar.indicatorWidth?.constant = indicatorWidth - indicatorDiff
+                if progress > 0.0 {
+                    let indicatorLeftMargin = bar.indicatorLeftMargin?.constant ?? 0.0
+                    bar.indicatorLeftMargin?.constant = indicatorLeftMargin + indicatorDiff
+                }
+            }
+            
             // bounce indicator at boundaries if required
-            guard bar.indicatorBounces else { return }
-            if (lowerButton === upperButton) {
+            if bar.indicatorBounces && isOutOfBounds {
                 let indicatorWidth = bar.indicatorWidth?.constant ?? 0.0
                 bar.indicatorLeftMargin?.constant = (bar.indicatorLeftMargin?.constant ?? 0.0) + (indicatorWidth * progress)
             }


### PR DESCRIPTION
- Add `compresses` property to indicator, to allow for it to 'compress' when scrolling beyond the edges of page ranges. 