### PR TITLE
Enabling TabmanViewController subclasses to decide if an item should be selected

### DIFF
--- a/Sources/Tabman/TabmanBar/Styles/Abstract/TabmanButtonBar.swift
+++ b/Sources/Tabman/TabmanBar/Styles/Abstract/TabmanButtonBar.swift
@@ -220,7 +220,7 @@ internal class TabmanButtonBar: TabmanBar {
     //
     
     internal func tabButtonPressed(_ sender: UIButton) {
-        if let index = self.buttons.index(of: sender) {
+        if let index = self.buttons.index(of: sender), (self.delegate?.bar(self, shouldSelectItemAt: index) ?? true) {            
             self.delegate?.bar(self, didSelectItemAt: index)
         }
     }

--- a/Sources/Tabman/TabmanBar/TabmanBar+Protocols.swift
+++ b/Sources/Tabman/TabmanBar/TabmanBar+Protocols.swift
@@ -20,6 +20,13 @@ public protocol TabmanBarDataSource: class {
 
 internal protocol TabmanBarDelegate: class {
     
+    /// Control if the bar should allow the given item to be selected.
+    ///
+    /// - Parameters:
+    ///   - bar: The bar.
+    ///   - index: The item index.
+    func bar(_ bar: TabmanBar, shouldSelectItemAt index: Int) -> Bool
+    
     /// The bar did select an item at an index.
     ///
     /// - Parameters:

--- a/Sources/Tabman/TabmanViewController.swift
+++ b/Sources/Tabman/TabmanViewController.swift
@@ -119,6 +119,10 @@ open class TabmanViewController: PageboyViewController, PageboyViewControllerDel
         self.insetChildViewControllerIfNeeded(self.currentViewController)
     }
     
+    open func tabmanViewController(shouldSelectItemAt index: Int) -> Bool {
+        return true
+    }
+    
     private func updateBar(withPosition position: CGFloat,
                            direction: PageboyViewController.NavigationDirection) {
         
@@ -220,6 +224,10 @@ extension TabmanViewController: TabmanBarDataSource, TabmanBarDelegate {
         }
         
         return self.bar.items
+    }
+    
+    public func bar(_ bar: TabmanBar, shouldSelectItemAt index: Int) -> Bool {
+        return self.tabmanViewController(shouldSelectItemAt: index)
     }
     
     public func bar(_ bar: TabmanBar, didSelectItemAt index: Int) {


### PR DESCRIPTION
This doesn't stop the user from scrolling between pages, and it's really only coherent if, like in my case, you would also disable scrolling. 

I looked into also disabling scrolling but I'm not seeing a good way to do it. Anyway, I think this is a useful addition to those that, like me, are disabling scrolling and going with a fade transition for example. 