### PR TITLE
Fix text font not being applied to block tab bar

### DIFF
--- a/Sources/Tabman/TabmanBar/Styles/TabmanBlockTabBar.swift
+++ b/Sources/Tabman/TabmanBar/Styles/TabmanBlockTabBar.swift
@@ -54,6 +54,17 @@ internal class TabmanBlockTabBar: TabmanStaticButtonBar {
         }
     }
     
+    override var textFont: UIFont {
+        didSet {
+            guard textFont != oldValue else { return }
+
+            updateButtonsInView(view: self.buttonContentView,
+                                update: { $0.titleLabel?.font = textFont })
+            updateButtonsInView(view: self.maskContentView,
+                                update: { $0.titleLabel?.font = textFont })
+        }
+    }
+    
     // MARK: Lifecycle
 
     override public func defaultIndicatorStyle() -> TabmanIndicator.Style {


### PR DESCRIPTION
Fix issue where custom textFont would not be applied to block tab bar mask buttons. #115 