### PR TITLE
Add ability to extend background edge insets under system components.

### DIFF
--- a/Docs/APPEARANCE.md
+++ b/Docs/APPEARANCE.md
@@ -53,7 +53,8 @@ bar.appearance.layout
 | `height` | `TabmanBar.Height` | The height for the bar. | `.auto` |
 | `itemVerticalPadding` | `CGFloat` | The vertical padding between the item and the bar bounds. | `12.0` |
 | `itemDistribution` | `ItemDistribution` | How items in the bar should be distributed. | `.leftAligned` |
-
+| `minimumItemWidth` | `CGFloat` | The minimum width for an item. | `44.0` |
+| `extendBackgroundEdgeInsets` | `Bool` | Whether to extend the background edge insets in certain scenarios. | `true` |
 
 ## State
 Customise how the bar should react to state changes.

--- a/Sources/Tabman.xcodeproj/project.pbxproj
+++ b/Sources/Tabman.xcodeproj/project.pbxproj
@@ -35,9 +35,9 @@
 		D62AC0F51E5733FE0020B8AE /* TabmanViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D62AC0F41E5733FE0020B8AE /* TabmanViewController.swift */; };
 		D62AC11C1E573AA00020B8AE /* TabmanBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D62AC11B1E573AA00020B8AE /* TabmanBar.swift */; };
 		D62AC1201E573FD20020B8AE /* TabmanBar+Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = D62AC11F1E573FD20020B8AE /* TabmanBar+Item.swift */; };
-		D62AC1231E5748D80020B8AE /* UIView+AutoLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = D62AC1221E5748D80020B8AE /* UIView+AutoLayout.swift */; };
 		D62AC1A91E5C54570020B8AE /* UIView+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = D62AC1A81E5C54570020B8AE /* UIView+Utils.swift */; };
 		D62AC1AB1E5C55290020B8AE /* ContentViewScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D62AC1AA1E5C55290020B8AE /* ContentViewScrollView.swift */; };
+		D63582201F5EF843006AD0C3 /* TabmanBar+Layout.swift in Sources */ = {isa = PBXBuildFile; fileRef = D635821F1F5EF843006AD0C3 /* TabmanBar+Layout.swift */; };
 		D637B2F81F13960900343713 /* UIScrollView+Interaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D637B2F71F13960900343713 /* UIScrollView+Interaction.swift */; };
 		D65F101D1EAEA2730090980C /* Pageboy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D65F101C1EAEA2730090980C /* Pageboy.framework */; };
 		D66F583C1EC0F66000418B40 /* TabmanButtonBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D66F583A1EC0F66000418B40 /* TabmanButtonBar.swift */; };
@@ -106,9 +106,9 @@
 		D62AC0F41E5733FE0020B8AE /* TabmanViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabmanViewController.swift; sourceTree = "<group>"; };
 		D62AC11B1E573AA00020B8AE /* TabmanBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabmanBar.swift; sourceTree = "<group>"; };
 		D62AC11F1E573FD20020B8AE /* TabmanBar+Item.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TabmanBar+Item.swift"; sourceTree = "<group>"; };
-		D62AC1221E5748D80020B8AE /* UIView+AutoLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+AutoLayout.swift"; sourceTree = "<group>"; };
 		D62AC1A81E5C54570020B8AE /* UIView+Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+Utils.swift"; sourceTree = "<group>"; };
 		D62AC1AA1E5C55290020B8AE /* ContentViewScrollView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentViewScrollView.swift; sourceTree = "<group>"; };
+		D635821F1F5EF843006AD0C3 /* TabmanBar+Layout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TabmanBar+Layout.swift"; sourceTree = "<group>"; };
 		D637B2F71F13960900343713 /* UIScrollView+Interaction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIScrollView+Interaction.swift"; sourceTree = "<group>"; };
 		D65F101C1EAEA2730090980C /* Pageboy.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Pageboy.framework; path = ../Carthage/Build/iOS/Pageboy.framework; sourceTree = "<group>"; };
 		D66F583A1EC0F66000418B40 /* TabmanButtonBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabmanButtonBar.swift; sourceTree = "<group>"; };
@@ -305,6 +305,7 @@
 				D66FEEBB1E79662C00E7E87A /* TabmanBar+Indicator.swift */,
 				D66FEEBD1E79670700E7E87A /* TabmanBar+Protocols.swift */,
 				D6F7FF4B1EC39E050077219B /* TabmanBar+Insets.swift */,
+				D635821F1F5EF843006AD0C3 /* TabmanBar+Layout.swift */,
 				D6020AA51E5DE4A800C2B7BA /* Styles */,
 				D616D09F1E77EFC600C7AA32 /* Transitioning */,
 				D62AC1AE1E5C84CB0020B8AE /* Components */,
@@ -316,7 +317,6 @@
 		D62AC1211E5748C80020B8AE /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
-				D62AC1221E5748D80020B8AE /* UIView+AutoLayout.swift */,
 				D62AC1A81E5C54570020B8AE /* UIView+Utils.swift */,
 				D637B2F71F13960900343713 /* UIScrollView+Interaction.swift */,
 				D62AC1AA1E5C55290020B8AE /* ContentViewScrollView.swift */,
@@ -532,9 +532,9 @@
 				D6020AA91E5DE4D600C2B7BA /* TabmanLineBar.swift in Sources */,
 				D66F583D1EC0F66000418B40 /* TabmanStaticButtonBar.swift in Sources */,
 				D616D0AC1E77FA9300C7AA32 /* TabmanIndicatorTransition.swift in Sources */,
+				D63582201F5EF843006AD0C3 /* TabmanBar+Layout.swift in Sources */,
 				D616D0B51E77FF6D00C7AA32 /* TabmanItemColorCrossfadeTransition.swift in Sources */,
 				D616D0A31E77EFC600C7AA32 /* TabmanBarTransitionStore.swift in Sources */,
-				D62AC1231E5748D80020B8AE /* UIView+AutoLayout.swift in Sources */,
 				D66FEEDC1E7AA51000E7E87A /* ViewUtils.swift in Sources */,
 				D68FBA811E701D1A00B96EC0 /* CircularView.swift in Sources */,
 				D616D06C1E72C1FC00C7AA32 /* TabmanLineIndicator.swift in Sources */,

--- a/Sources/Tabman/TabmanBar/Components/Background/TabmanBar+BackgroundView.swift
+++ b/Sources/Tabman/TabmanBar/Components/Background/TabmanBar+BackgroundView.swift
@@ -28,9 +28,9 @@ public extension TabmanBar {
         // MARK: Properties
         //
         
-        var backgroundStyle: Style = TabmanBar.Appearance.defaultAppearance.style.background ?? .clear {
+        var style: Style = TabmanBar.Appearance.defaultAppearance.style.background ?? .clear {
             didSet {
-                self.updateBackground(forStyle: backgroundStyle)
+                self.updateBackground(for: style)
             }
         }
         
@@ -42,26 +42,26 @@ public extension TabmanBar {
         
         public override init(frame: CGRect) {
             super.init(frame: frame)
-            initBackgroundView()
+            configure()
         }
         
         required public init?(coder aDecoder: NSCoder) {
             super.init(coder: aDecoder)
-            initBackgroundView()
+            configure()
         }
         
-        private func initBackgroundView() {
+        private func configure() {
             self.addSubview(self.backgroundContainer)
             self.backgroundContainer.autoPinEdgesToSuperviewEdges()
             
-            self.updateBackground(forStyle: backgroundStyle)
+            self.updateBackground(for: style)
         }
         
         //
         // MARK: Lifecycle
         //
         
-        func updateBackground(forStyle style: Style) {
+        func updateBackground(for style: Style) {
             self.backgroundContainer.removeAllSubviews()
             
             switch style {

--- a/Sources/Tabman/TabmanBar/Components/Background/TabmanBar+BackgroundView.swift
+++ b/Sources/Tabman/TabmanBar/Components/Background/TabmanBar+BackgroundView.swift
@@ -18,7 +18,7 @@ public extension TabmanBar {
         // MARK: Types
         //
         
-        public enum BackgroundStyle {
+        public enum Style {
             case clear
             case blur(style: UIBlurEffectStyle)
             case solid(color: UIColor)
@@ -28,7 +28,7 @@ public extension TabmanBar {
         // MARK: Properties
         //
         
-        var backgroundStyle: BackgroundStyle = TabmanBar.Appearance.defaultAppearance.style.background ?? .clear {
+        var backgroundStyle: Style = TabmanBar.Appearance.defaultAppearance.style.background ?? .clear {
             didSet {
                 self.updateBackground(forStyle: backgroundStyle)
             }
@@ -61,7 +61,7 @@ public extension TabmanBar {
         // MARK: Lifecycle
         //
         
-        func updateBackground(forStyle style: BackgroundStyle) {
+        func updateBackground(forStyle style: Style) {
             self.backgroundContainer.removeAllSubviews()
             
             switch style {
@@ -83,7 +83,7 @@ public extension TabmanBar {
     }
 }
 
-extension TabmanBar.BackgroundView.BackgroundStyle: CustomStringConvertible, Equatable {
+extension TabmanBar.BackgroundView.Style: CustomStringConvertible, Equatable {
     
     public var description: String {
         switch self {
@@ -98,8 +98,8 @@ extension TabmanBar.BackgroundView.BackgroundStyle: CustomStringConvertible, Equ
         }
     }
     
-    public static func ==(lhs: TabmanBar.BackgroundView.BackgroundStyle,
-                          rhs: TabmanBar.BackgroundView.BackgroundStyle) -> Bool {
+    public static func ==(lhs: TabmanBar.BackgroundView.Style,
+                          rhs: TabmanBar.BackgroundView.Style) -> Bool {
         return lhs.description == rhs.description
     }
 }

--- a/Sources/Tabman/TabmanBar/TabmanBar+Appearance.swift
+++ b/Sources/Tabman/TabmanBar/TabmanBar+Appearance.swift
@@ -59,6 +59,10 @@ public extension TabmanBar {
             public var itemDistribution: ItemDistribution?
             /// The minimum width for item
             public var minimumItemWidth: CGFloat?
+            /// Whether to extend the background edge insets in certain scenarios.
+            /// For example when the bar is against the status bar, the background 
+            /// will extend underneath the status bar.
+            public var extendBackgroundEdgeInsets: Bool?
         }
         
         public struct State {
@@ -137,6 +141,7 @@ public extension TabmanBar {
             self.layout.itemVerticalPadding = 12.0
             self.layout.itemDistribution = .leftAligned
             self.layout.minimumItemWidth = 44.0
+            self.layout.extendBackgroundEdgeInsets = true
             
             // style
             self.style.background = .blur(style: .extraLight)

--- a/Sources/Tabman/TabmanBar/TabmanBar+Appearance.swift
+++ b/Sources/Tabman/TabmanBar/TabmanBar+Appearance.swift
@@ -72,7 +72,7 @@ public extension TabmanBar {
         
         public struct Style {
             /// The background style for the bar.
-            public var background: TabmanBar.BackgroundView.BackgroundStyle?
+            public var background: TabmanBar.BackgroundView.Style?
             /// Whether to show a fade on the items at the bounds edge of a scrolling button bar.
             public var showEdgeFade: Bool?
             /// Color of the separator at the bottom of the bar.

--- a/Sources/Tabman/TabmanBar/TabmanBar+Layout.swift
+++ b/Sources/Tabman/TabmanBar/TabmanBar+Layout.swift
@@ -62,9 +62,10 @@ internal extension TabmanBar {
     ///   - location: The location of the bar.
     ///   - topLayoutGuide: The TabmanViewController top layout guide.
     func extendBackgroundForStatusBarIfNeeded(location: TabmanBar.Location,
-                                              topLayoutGuide: UILayoutSupport) {
+                                              topLayoutGuide: UILayoutSupport,
+                                              appearance: TabmanBar.Appearance) {
         guard let topPinConstraint = self.backgroundView.constraints.first else { return }
-        guard location == .top else {
+        guard location == .top, appearance.layout.extendBackgroundEdgeInsets ?? false else {
             topPinConstraint.constant = 0.0
             return
         }

--- a/Sources/Tabman/TabmanBar/TabmanBar+Layout.swift
+++ b/Sources/Tabman/TabmanBar/TabmanBar+Layout.swift
@@ -1,5 +1,5 @@
 //
-//  UIView+AutoLayout.swift
+//  TabmanBar+Layout.swift
 //  Tabman
 //
 //  Created by Merrick Sapsford on 17/02/2017.
@@ -54,5 +54,24 @@ internal extension TabmanBar {
         
         self.superview?.addConstraints(constraints)
         return constraints
+    }
+    
+    /// Extends the bar background view underneath status bar if applicable.
+    ///
+    /// - Parameters:
+    ///   - location: The location of the bar.
+    ///   - topLayoutGuide: The TabmanViewController top layout guide.
+    func extendBackgroundForStatusBarIfNeeded(location: TabmanBar.Location,
+                                              topLayoutGuide: UILayoutSupport) {
+        guard let topPinConstraint = self.backgroundView.constraints.first else { return }
+        guard location == .top else {
+            topPinConstraint.constant = 0.0
+            return
+        }
+        
+        let statusBarHeight = UIApplication.shared.statusBarFrame.height
+        if topLayoutGuide.length == statusBarHeight {
+            self.backgroundView.constraints.first?.constant = -statusBarHeight
+        }
     }
 }

--- a/Sources/Tabman/TabmanBar/TabmanBar.swift
+++ b/Sources/Tabman/TabmanBar/TabmanBar.swift
@@ -280,8 +280,7 @@ open class TabmanBar: UIView, TabmanBarLifecycle {
         self.preferredIndicatorStyle = appearance.indicator.preferredStyle
         
         let backgroundStyle = appearance.style.background ?? defaultAppearance.style.background!
-        self.backgroundView.backgroundStyle = backgroundStyle
-        
+        self.backgroundView.style = backgroundStyle
         
         let height : Height
         let hideWhenSingleItem = appearance.state.shouldHideWhenSingleItem ?? defaultAppearance.state.shouldHideWhenSingleItem!

--- a/Sources/Tabman/TabmanViewController.swift
+++ b/Sources/Tabman/TabmanViewController.swift
@@ -76,7 +76,8 @@ open class TabmanViewController: PageboyViewController, PageboyViewControllerDel
         reloadBarWithCurrentPosition()
         
         activeTabmanBar?.extendBackgroundForStatusBarIfNeeded(location: bar.location,
-                                                              topLayoutGuide: self.topLayoutGuide)
+                                                              topLayoutGuide: self.topLayoutGuide,
+                                                              appearance: bar.appearance ?? .defaultAppearance)
 
     }
     

--- a/Sources/Tabman/TabmanViewController.swift
+++ b/Sources/Tabman/TabmanViewController.swift
@@ -74,6 +74,10 @@ open class TabmanViewController: PageboyViewController, PageboyViewControllerDel
         reloadRequiredBarInsets()
         insetChildViewControllerIfNeeded(self.currentViewController)
         reloadBarWithCurrentPosition()
+        
+        activeTabmanBar?.extendBackgroundForStatusBarIfNeeded(location: bar.location,
+                                                              topLayoutGuide: self.topLayoutGuide)
+
     }
     
     open override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {


### PR DESCRIPTION
Adds the ability for a `TabmanBar.BackgroundView` to extend under the system status bar in certain layout scenarios. For example, if embedded in a `UINavigationController` where the navigation bar is hidden. #135 