### PR TITLE
Added context property to tab bar item

### DIFF
--- a/Sources/Tabman/TabmanBar/TabmanBar+Item.swift
+++ b/Sources/Tabman/TabmanBar/TabmanBar+Item.swift
@@ -19,30 +19,35 @@ public extension TabmanBar {
         public private(set) var title: String?
         /// The image to display for the item.
         public private(set) var image: UIImage?
+		/// Context of the item for external reference.
+		public private(set) var context: Any?
         
         // MARK: Init
         
         /// Create an item with a title.
         ///
         /// - Parameter title: The title to display.
-        public init(title: String) {
+		public init(title: String, context: Any? = nil) {
             self.title = title
+			self.context = context
         }
         
         /// Create an item with an image.
         ///
         /// - Parameter image: Image to display.
-        public init(image: UIImage) {
+        public init(image: UIImage, context: Any? = nil) {
             self.image = image
+			self.context = context
         }
       
         /// Create an item with a title and an image
         ///
         /// - Parameter title: The title to display.
         /// - Parameter image: Image to display.
-        public init(title: String, image: UIImage) {
+        public init(title: String, image: UIImage, context: Any? = nil) {
             self.title = title
             self.image = image
+			self.context = context
         }
     }
 }


### PR DESCRIPTION
With the new lazy-load data source, it's useful to have the ability to attach arbitrary data to a tab bar item for later reference. For example, if you're going to have a bunch of tabs where each tab displays data for a specific date, you could calculate all those dates one time, set the title of the tab to the date, and attach that date object to the item as its context. Then when you're loading the view controller, you can get the date object back out of the item.

Sample usage shown here:

	private func loadData() {			
			var barItems: [Item] = []
			for daysAhead in 1...6 {
				let date = Date()
				let itemTitle = DateFormatter.localizedString(from: date, dateStyle: .short, timeStyle: .none)
				barItems.append(Item(title: itemTitle, context: date))
			}
			
			// configure the bar
			self.bar.items = barItems
		}
	}

Then in the data source:

	func viewController(for pageboyViewController: PageboyViewController, at index: PageboyViewController.PageIndex) -> UIViewController? {
		guard let date = self.bar.items?[index].context as? Date else {
			return nil
		}
		
		let vc = self.storyboard?.instantiateViewController(withIdentifier: "DateViewController") as! DateViewController
		vc.showDate = date
		
		return vc
	}

Without the date context you would need to recalculate the date each time you're asked for a new view controller. Not only is this potentially expensive depending on your dataset, but this also leaves the opportunity to make the tab bar items and the actual view controllers out of sync. By using the tab bar item's context directly, that tab item will always show the data it's intended to.