### PR TITLE
Add `imageRenderingMode` option to `TabmanBar.Appearance.Style`

### DIFF
--- a/Sources/Tabman.xcodeproj/project.pbxproj
+++ b/Sources/Tabman.xcodeproj/project.pbxproj
@@ -111,7 +111,7 @@
 		D635821F1F5EF843006AD0C3 /* TabmanBar+Layout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TabmanBar+Layout.swift"; sourceTree = "<group>"; };
 		D637B2F71F13960900343713 /* UIScrollView+Interaction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIScrollView+Interaction.swift"; sourceTree = "<group>"; };
 		D65F101C1EAEA2730090980C /* Pageboy.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Pageboy.framework; path = ../Carthage/Build/iOS/Pageboy.framework; sourceTree = "<group>"; };
-		D66F583A1EC0F66000418B40 /* TabmanButtonBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabmanButtonBar.swift; sourceTree = "<group>"; };
+		D66F583A1EC0F66000418B40 /* TabmanButtonBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = TabmanButtonBar.swift; sourceTree = "<group>"; tabWidth = 4; };
 		D66F583B1EC0F66000418B40 /* TabmanStaticButtonBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabmanStaticButtonBar.swift; sourceTree = "<group>"; };
 		D66FEEBB1E79662C00E7E87A /* TabmanBar+Indicator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TabmanBar+Indicator.swift"; sourceTree = "<group>"; };
 		D66FEEBD1E79670700E7E87A /* TabmanBar+Protocols.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TabmanBar+Protocols.swift"; sourceTree = "<group>"; };

--- a/Sources/Tabman/TabmanBar/Styles/Abstract/TabmanButtonBar.swift
+++ b/Sources/Tabman/TabmanBar/Styles/Abstract/TabmanButtonBar.swift
@@ -58,8 +58,23 @@ internal class TabmanButtonBar: TabmanBar {
             })
         }
     }
+    
     public var color: UIColor = Appearance.defaultAppearance.state.color!
     public var selectedColor: UIColor = Appearance.defaultAppearance.state.selectedColor!
+  
+    public var imageRenderingMode: UIImageRenderingMode = Appearance.defaultAppearance.style.imageRenderingMode! {
+        didSet {
+            guard oldValue != imageRenderingMode else {
+                return
+            }
+            updateButtons(update: {
+                guard let image = $0.currentImage else {
+                    return
+                }
+                $0.setImage(image.withRenderingMode(imageRenderingMode), for: .normal)
+            })
+        }
+    }
     
     public var itemVerticalPadding: CGFloat = Appearance.defaultAppearance.layout.itemVerticalPadding! {
         didSet {
@@ -142,6 +157,8 @@ internal class TabmanButtonBar: TabmanBar {
         let edgeInset = appearance.layout.edgeInset
         self.edgeInset = edgeInset ?? defaultAppearance.layout.edgeInset!
         
+        self.imageRenderingMode = appearance.style.imageRenderingMode ?? defaultAppearance.style.imageRenderingMode!
+        
         // update left margin for progressive style
         if self.indicator?.isProgressiveCapable ?? false {
             
@@ -175,7 +192,7 @@ internal class TabmanButtonBar: TabmanBar {
                 // resize images to fit
                 let resizedImage = image.resize(toSize: Defaults.titleWithImageSize)
                 if resizedImage.size != .zero {
-                    button.setImage(resizedImage.withRenderingMode(.alwaysTemplate), for: .normal)
+                    button.setImage(resizedImage.withRenderingMode(imageRenderingMode), for: .normal)
                 }
                 button.setTitle(title, for: .normal)
                 // Nudge it over a little bit
@@ -186,7 +203,7 @@ internal class TabmanButtonBar: TabmanBar {
                 // resize images to fit
                 let resizedImage = image.resize(toSize: Defaults.itemImageSize)
                 if resizedImage.size != .zero {
-                    button.setImage(resizedImage.withRenderingMode(.alwaysTemplate), for: .normal)
+                    button.setImage(resizedImage.withRenderingMode(imageRenderingMode), for: .normal)
                 }
             }
             

--- a/Sources/Tabman/TabmanBar/TabmanBar+Appearance.swift
+++ b/Sources/Tabman/TabmanBar/TabmanBar+Appearance.swift
@@ -81,6 +81,8 @@ public extension TabmanBar {
             public var showEdgeFade: Bool?
             /// Color of the separator at the bottom of the bar.
             public var bottomSeparatorColor: UIColor?
+            /// The image rendering mode for items that have an image
+            public var imageRenderingMode: UIImageRenderingMode?
         }
         
         public struct Text {
@@ -146,7 +148,8 @@ public extension TabmanBar {
             // style
             self.style.background = .blur(style: .extraLight)
             self.style.bottomSeparatorColor = .clear
-            
+            self.style.imageRenderingMode = .alwaysTemplate
+          
             // interaction
             self.interaction.isScrollEnabled = true
         }


### PR DESCRIPTION
Just added a field to the Style struct with type UIImageRenderingMode so that images displayed in the tab bar can have color if desired. My use case for this is that each page has information that can be filled out, and we want to show if anything has been changed with red/green images. 
