### PR TITLE
Add improved support for safeAreaInsets and iPhone X

### DIFF
--- a/Example/Tabman-Example/TabViewController.swift
+++ b/Example/Tabman-Example/TabViewController.swift
@@ -33,20 +33,20 @@ class TabViewController: TabmanViewController, PageboyViewControllerDataSource {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.addBarButtons()
-        self.view.sendSubview(toBack: self.gradientView)
+        addBarButtons()
+        view.sendSubview(toBack: self.gradientView)
                 
-        self.dataSource = self
+        dataSource = self
         
         // bar customisation
-        self.bar.location = .top
-//        self.bar.style = .custom(type: CustomTabmanBar.self) // uncomment to use CustomTabmanBar as style.
-        self.bar.appearance = PresetAppearanceConfigs.forStyle(self.bar.style, currentAppearance: self.bar.appearance)
+        bar.location = .top
+//        bar.style = .custom(type: CustomTabmanBar.self) // uncomment to use CustomTabmanBar as style.
+        bar.appearance = PresetAppearanceConfigs.forStyle(self.bar.style, currentAppearance: self.bar.appearance)
         
         // updating
-        self.updateAppearance(pagePosition: self.currentPosition?.x ?? 0.0)
-        self.updateStatusLabels()
-        self.updateBarButtonStates(index: self.currentIndex ?? 0)
+        updateAppearance(pagePosition: currentPosition?.x ?? 0.0)
+        updateStatusLabels()
+        updateBarButtonStates(index: currentIndex ?? 0)
     }
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
@@ -72,18 +72,18 @@ class TabViewController: TabmanViewController, PageboyViewControllerDataSource {
     // MARK: Actions
     
     @objc func firstPage(_ sender: UIBarButtonItem) {
-        self.scrollToPage(.first, animated: true)
+        scrollToPage(.first, animated: true)
     }
     
     @objc func lastPage(_ sender: UIBarButtonItem) {
-        self.scrollToPage(.last, animated: true)
+        scrollToPage(.last, animated: true)
     }
     
     // MARK: PageboyViewControllerDataSource
 
     func numberOfViewControllers(in pageboyViewController: PageboyViewController) -> Int {
         var count = 0
-        switch self.bar.style {
+        switch bar.style {
         case .blockTabBar, .buttonBar:
             count = 3
         default:
@@ -107,7 +107,7 @@ class TabViewController: TabmanViewController, PageboyViewControllerDataSource {
             viewControllers.append(viewController)
         }
 
-        self.bar.items = barItems
+        bar.items = barItems
         self.viewControllers = viewControllers
     }
     
@@ -132,7 +132,7 @@ class TabViewController: TabmanViewController, PageboyViewControllerDataSource {
                                     direction: direction,
                                     animated: animated)
         
-        self.targetIndex = index
+        targetIndex = index
     }
 
     override func pageboyViewController(_ pageboyViewController: PageboyViewController,
@@ -144,8 +144,8 @@ class TabViewController: TabmanViewController, PageboyViewControllerDataSource {
                                     direction: direction,
                                     animated: animated)
         
-        self.updateAppearance(pagePosition: position.x)
-        self.updateStatusLabels()
+        updateAppearance(pagePosition: position.x)
+        updateStatusLabels()
     }
     
     override func pageboyViewController(_ pageboyViewController: PageboyViewController,
@@ -157,10 +157,10 @@ class TabViewController: TabmanViewController, PageboyViewControllerDataSource {
                                     direction: direction,
                                     animated: animated)
         
-        self.updateAppearance(pagePosition: CGFloat(index))
-        self.updateStatusLabels()
-        self.updateBarButtonStates(index: index)
+        updateAppearance(pagePosition: CGFloat(index))
+        updateStatusLabels()
+        updateBarButtonStates(index: index)
         
-        self.targetIndex = nil
+        targetIndex = nil
     }
 }

--- a/Sources/Tabman/TabmanBar/TabmanBar+Insets.swift
+++ b/Sources/Tabman/TabmanBar/TabmanBar+Insets.swift
@@ -17,9 +17,17 @@ public extension TabmanBar {
         internal let barInsets: UIEdgeInsets
         
         /// The inset required for the top layout guide (UINavigationBar etc.).
-        public let topLayoutGuide: CGFloat
+        @available(*, deprecated: 1.0.1, message: "Use safeAreaInsets")
+        public var topLayoutGuide: CGFloat {
+            return safeAreaInsets.top
+        }
         /// The inset required for the bottom layout guide (UITabBar etc.).
-        public let bottomLayoutGuide: CGFloat
+        @available(*, deprecated: 1.0.1, message: "Use safeAreaInsets")
+        public var bottomLayoutGuide: CGFloat {
+            return safeAreaInsets.bottom
+        }
+        /// The insets that determine the safe area for the view controller view.
+        public let safeAreaInsets: UIEdgeInsets
         /// The inset required for the bar.
         public var bar: CGFloat {
             return max(barInsets.top, barInsets.bottom)
@@ -30,8 +38,8 @@ public extension TabmanBar {
         /// This takes topLayoutGuide, bottomlayoutGuide and the bar height into account.
         /// Set on a UIScrollView's contentInset to manually inset the contents.
         public var all: UIEdgeInsets {
-            let top = topLayoutGuide + barInsets.top
-            let bottom = bottomLayoutGuide + barInsets.bottom
+            let top = safeAreaInsets.top + barInsets.top
+            let bottom = safeAreaInsets.bottom + barInsets.bottom
             
             if barInsets.top > 0.0 {
                 return UIEdgeInsetsMake(top, 0.0, 0.0, 0.0)
@@ -42,17 +50,14 @@ public extension TabmanBar {
         
         // MARK: Init
         
-        internal init(topLayoutGuide: CGFloat,
-                      bottomLayoutGuide: CGFloat,
+        internal init(safeAreaInsets: UIEdgeInsets,
                       bar: UIEdgeInsets) {
-            self.topLayoutGuide = topLayoutGuide
-            self.bottomLayoutGuide = bottomLayoutGuide
+            self.safeAreaInsets = safeAreaInsets
             self.barInsets = bar
         }
         
         internal init() {
-            self.init(topLayoutGuide: 0.0,
-                      bottomLayoutGuide: 0.0,
+            self.init(safeAreaInsets: .zero,
                       bar: .zero)
         }
         

--- a/Sources/Tabman/TabmanViewController+Insetting.swift
+++ b/Sources/Tabman/TabmanViewController+Insetting.swift
@@ -13,8 +13,16 @@ internal extension TabmanViewController {
     
     /// Reload the required bar insets for the current bar.
     func reloadRequiredBarInsets() {
-        self.bar.requiredInsets = TabmanBar.Insets(topLayoutGuide: self.topLayoutGuide.length,
-                                                   bottomLayoutGuide: self.bottomLayoutGuide.length,
+        
+        var layoutInsets: UIEdgeInsets = .zero
+        if #available(iOS 11, *) {
+            layoutInsets = view.safeAreaInsets
+        } else {
+            layoutInsets.top = topLayoutGuide.length
+            layoutInsets.bottom = bottomLayoutGuide.length
+        }
+        
+        self.bar.requiredInsets = TabmanBar.Insets(safeAreaInsets: layoutInsets,
                                                    bar: self.calculateRequiredBarInsets())
     }
     
@@ -69,11 +77,9 @@ internal extension TabmanViewController {
             guard let scrollView = scrollView else { continue }
             guard !scrollView.isBeingInteracted else { continue }
             
-            var requiredContentInset = self.bar.requiredInsets.barInsets
+            var requiredContentInset = self.bar.requiredInsets.all
             let currentContentInset = self.viewControllerInsets[scrollView.hash] ?? .zero
             
-            requiredContentInset.top += self.topLayoutGuide.length
-            requiredContentInset.bottom += self.bottomLayoutGuide.length
             self.viewControllerInsets[scrollView.hash] = requiredContentInset
             
             // take account of custom top / bottom insets

--- a/Sources/Tabman/TabmanViewController+Insetting.swift
+++ b/Sources/Tabman/TabmanViewController+Insetting.swift
@@ -77,6 +77,10 @@ internal extension TabmanViewController {
             guard let scrollView = scrollView else { continue }
             guard !scrollView.isBeingInteracted else { continue }
             
+            if #available(iOS 11.0, *) {
+                scrollView.contentInsetAdjustmentBehavior = .never
+            }
+            
             var requiredContentInset = self.bar.requiredInsets.all
             let currentContentInset = self.viewControllerInsets[scrollView.hash] ?? .zero
             

--- a/Sources/Tabman/TabmanViewController.swift
+++ b/Sources/Tabman/TabmanViewController.swift
@@ -40,11 +40,12 @@ open class TabmanViewController: PageboyViewController, PageboyViewControllerDel
     
     /// Internal store for bar component transitions.
     internal var barTransitionStore = TabmanBarTransitionStore()
+    /// Collection of cached insets for view controllers per page index.
+    internal var viewControllerInsets: [PageIndex : UIEdgeInsets] = [:]
     
-    internal var viewControllerInsets: [Int : UIEdgeInsets] = [:]
-    
-    /// Whether any UICollectionView / UITableView in child view controllers should be 
+    /// Whether any UIScrollView in child view controllers should be
     /// automatically insetted to display below the TabmanBar.
+    /// NOTE: This needs to be set before a dataSource is set, defaults to true.
     public var automaticallyAdjustsChildScrollViewInsets: Bool = true {
         didSet {
             if automaticallyAdjustsScrollViewInsets {


### PR DESCRIPTION
Update insetting logic to use `safeAreaInsets` rather than layout guides, fixing iOS 11 insetting issues and adding iPhone X support.

#146 