### PR TITLE
Adjust the `all` insets to always take into account the safe area.

### DIFF
--- a/Sources/Tabman/TabmanBar/TabmanBar+Insets.swift
+++ b/Sources/Tabman/TabmanBar/TabmanBar+Insets.swift
@@ -42,9 +42,9 @@ public extension TabmanBar {
             let bottom = safeAreaInsets.bottom + barInsets.bottom
             
             if barInsets.top > 0.0 {
-                return UIEdgeInsetsMake(top, 0.0, 0.0, 0.0)
+                return UIEdgeInsetsMake(top, 0.0, safeAreaInsets.bottom, 0.0)
             } else {
-                return UIEdgeInsetsMake(0.0, 0.0, bottom, 0.0)
+                return UIEdgeInsetsMake(safeAreaInsets.top, 0.0, bottom, 0.0)
             }
         }
         


### PR DESCRIPTION
Noticed this because I'm using both a tab bar controller and a navigation controller.

I'm not sure if the `if` test is need though? The following also worked for me:
```swift
let top = safeAreaInsets.top + barInsets.top
let bottom = safeAreaInsets.bottom + barInsets.bottom
            
return UIEdgeInsetsMake(top, 0.0, bottom, 0.0)
```