### PR TITLE
Add support for separator edge insets

### DIFF
--- a/Sources/Tabman.xcodeproj/project.pbxproj
+++ b/Sources/Tabman.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		463F17C01E81D6B100E5A993 /* Separator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463F17BF1E81D6B100E5A993 /* Separator.swift */; };
+		463F17C01E81D6B100E5A993 /* SeparatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463F17BF1E81D6B100E5A993 /* SeparatorView.swift */; };
 		D60136791E69893A0013CD42 /* TabmanIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60136781E69893A0013CD42 /* TabmanIndicator.swift */; };
 		D601368A1E6992BB0013CD42 /* TabmanBar+BackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60136891E6992BB0013CD42 /* TabmanBar+BackgroundView.swift */; };
 		D6020A981E5DC59500C2B7BA /* ColorUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6020A971E5DC59500C2B7BA /* ColorUtils.swift */; };
@@ -75,7 +75,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		463F17BF1E81D6B100E5A993 /* Separator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Separator.swift; sourceTree = "<group>"; };
+		463F17BF1E81D6B100E5A993 /* SeparatorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeparatorView.swift; sourceTree = "<group>"; };
 		D60136781E69893A0013CD42 /* TabmanIndicator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabmanIndicator.swift; sourceTree = "<group>"; };
 		D60136891E6992BB0013CD42 /* TabmanBar+BackgroundView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TabmanBar+BackgroundView.swift"; sourceTree = "<group>"; };
 		D6020A971E5DC59500C2B7BA /* ColorUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorUtils.swift; sourceTree = "<group>"; };
@@ -159,7 +159,7 @@
 		463F17BE1E81D6A900E5A993 /* Separator */ = {
 			isa = PBXGroup;
 			children = (
-				463F17BF1E81D6B100E5A993 /* Separator.swift */,
+				463F17BF1E81D6B100E5A993 /* SeparatorView.swift */,
 			);
 			path = Separator;
 			sourceTree = "<group>";
@@ -541,7 +541,7 @@
 				D616D0B91E78065500C7AA32 /* PositionalUtils.swift in Sources */,
 				D616D0B31E77FD5000C7AA32 /* TabmanTransition.swift in Sources */,
 				D616D0AD1E77FA9300C7AA32 /* TabmanScrollingBarIndicatorTransition.swift in Sources */,
-				463F17C01E81D6B100E5A993 /* Separator.swift in Sources */,
+				463F17C01E81D6B100E5A993 /* SeparatorView.swift in Sources */,
 				D683B9C71EEE8EF800FC765E /* TabmanBar+Config.swift in Sources */,
 				D637B2F81F13960900343713 /* UIScrollView+Interaction.swift in Sources */,
 				D66FEEC01E79688000E7E87A /* TabmanBar+Construction.swift in Sources */,

--- a/Sources/Tabman/TabmanBar/Components/Separator/Separator.swift
+++ b/Sources/Tabman/TabmanBar/Components/Separator/Separator.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import PureLayout
 
 internal class Separator: UIView {
     
@@ -14,19 +15,30 @@ internal class Separator: UIView {
     // MARK: Properties
     //
     
-    public override var intrinsicContentSize: CGSize {
+    private var leftPinConstraint: NSLayoutConstraint?
+    private var rightPinConstraint: NSLayoutConstraint?
+    
+    override var intrinsicContentSize: CGSize {
         return CGSize(width: 0.0, height: 0.5)
     }
     
-    public override var tintColor: UIColor! {
+    override var tintColor: UIColor! {
         didSet {
             self.color = tintColor
         }
     }
     /// The color of the separator.
-    public var color: UIColor = .clear {
+    var color: UIColor = .clear {
         didSet {
             self.backgroundColor = color
+        }
+    }
+    /// The distance to inset the separator from it's superview (X-axis only).
+    var edgeInsets: UIEdgeInsets = .zero {
+        didSet {
+            leftPinConstraint?.constant = edgeInsets.left
+            rightPinConstraint?.constant = -edgeInsets.right
+            superview?.layoutIfNeeded()
         }
     }
     
@@ -51,5 +63,15 @@ internal class Separator: UIView {
     private func initSeparator() {
         
         self.backgroundColor = self.color
+    }
+    
+    // MARK: Layout
+    
+    func addAsSubview(to parent: UIView) {
+        
+        parent.addSubview(self)
+        autoPinEdge(toSuperviewEdge: .bottom)
+        leftPinConstraint = autoPinEdge(toSuperviewEdge: .leading)
+        rightPinConstraint = autoPinEdge(toSuperviewEdge: .trailing)
     }
 }

--- a/Sources/Tabman/TabmanBar/Components/Separator/SeparatorView.swift
+++ b/Sources/Tabman/TabmanBar/Components/Separator/SeparatorView.swift
@@ -1,5 +1,5 @@
 //
-//  Separator.swift
+//  SeparatorView.swift
 //  Tabman
 //
 //  Created by Merrick Sapsford on 21/03/2017.

--- a/Sources/Tabman/TabmanBar/Components/Separator/SeparatorView.swift
+++ b/Sources/Tabman/TabmanBar/Components/Separator/SeparatorView.swift
@@ -9,7 +9,7 @@
 import UIKit
 import PureLayout
 
-internal class Separator: UIView {
+internal class SeparatorView: UIView {
     
     //
     // MARK: Properties

--- a/Sources/Tabman/TabmanBar/TabmanBar+Appearance.swift
+++ b/Sources/Tabman/TabmanBar/TabmanBar+Appearance.swift
@@ -51,6 +51,8 @@ public extension TabmanBar {
             public var interItemSpacing: CGFloat?
             /// The spacing at the edge of the items in the bar.
             public var edgeInset: CGFloat?
+            /// Edge insets for the bottom separator relative to the bar.
+            public var bottomSeparatorEdgeInsets: UIEdgeInsets?
             /// The height for the bar.
             public var height: TabmanBar.Height?
             /// The vertical padding between the item and the bar bounds.
@@ -140,6 +142,7 @@ public extension TabmanBar {
             self.layout.height = .auto
             self.layout.interItemSpacing = 20.0
             self.layout.edgeInset = 16.0
+            self.layout.bottomSeparatorEdgeInsets = .zero
             self.layout.itemVerticalPadding = 12.0
             self.layout.itemDistribution = .leftAligned
             self.layout.minimumItemWidth = 44.0

--- a/Sources/Tabman/TabmanBar/TabmanBar.swift
+++ b/Sources/Tabman/TabmanBar/TabmanBar.swift
@@ -101,7 +101,7 @@ open class TabmanBar: UIView, TabmanBarLifecycle {
     /// The content view for the bar.
     public private(set) var contentView = UIView(forAutoLayout: ())
     /// The bottom separator view for the bar.
-    internal private(set) var bottomSeparator = Separator()
+    internal private(set) var bottomSeparator = SeparatorView()
     /// Indicator for the bar.
     public internal(set) var indicator: TabmanIndicator? {
         didSet {

--- a/Sources/Tabman/TabmanBar/TabmanBar.swift
+++ b/Sources/Tabman/TabmanBar/TabmanBar.swift
@@ -162,8 +162,7 @@ open class TabmanBar: UIView, TabmanBarLifecycle {
         self.addSubview(backgroundView)
         backgroundView.autoPinEdgesToSuperviewEdges()
         
-        self.addSubview(bottomSeparator)
-        bottomSeparator.autoPinEdgesToSuperviewEdges(with: .zero, excludingEdge: .top)
+        bottomSeparator.addAsSubview(to: self)
         
         self.addSubview(contentView)
         contentView.autoPinEdgesToSuperviewEdges()

--- a/Sources/Tabman/TabmanBar/TabmanBar.swift
+++ b/Sources/Tabman/TabmanBar/TabmanBar.swift
@@ -292,6 +292,8 @@ open class TabmanBar: UIView, TabmanBarLifecycle {
         
         let bottomSeparatorColor = appearance.style.bottomSeparatorColor ?? defaultAppearance.style.bottomSeparatorColor!
         self.bottomSeparator.color = bottomSeparatorColor
+        let bottomSeparatorEdgeInsets = appearance.layout.bottomSeparatorEdgeInsets ?? defaultAppearance.layout.bottomSeparatorEdgeInsets!
+        self.bottomSeparator.edgeInsets = bottomSeparatorEdgeInsets
         
         self.update(forAppearance: appearance,
                     defaultAppearance: defaultAppearance)


### PR DESCRIPTION
Add `edgeInsets` property to `SeparatorView`, and exposes it via `bottomSeparatorEdgeInsets` in `TabmanBar.Appearance.layout`. #176 