### PR TITLE
Remove UIViewController from TMBarItemable

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -35,6 +35,7 @@ custom_categories:
     children:
     - TMBar
     - TMBarView
+    - TMBarItemable
     - TMBarItem
     - TMBarDataSource
     - TMBarDelegate

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ class TabViewController: TabmanViewController {
     }
 }
 ```
+
 *When adding a bar, you can choose to add it to the predefined areas (`.top`, `.bottom`) or to a custom view with `.custom(view, layout)`. If you set `layout` to be `nil`, the bar will be constrained to leading, trailing, top and bottom anchors of the view automatically.*
 
 4) Configure your data sources.
@@ -95,12 +96,14 @@ extension TabViewController: PageboyViewControllerDataSource, BarDataSource {
         return nil
     }
 
-    func barItem(for tabViewController: TabmanViewController, at index: Int) -> BarItem {
+    func barItem(for tabViewController: TabmanViewController, at index: Int) -> TMBarItemable {
         let title = "Page \(index)"
-        return BarItem(title: title)
+        return TMBarItem(title: title)
     }
 }
 ```
+
+*UIKit objects such as `UINavigationItem` and `UITabBarItem` also conform to `TMBarItemable`.*
 
 ### Choosing a look
 Tabman provides numerous, easy to use template styles out of the box:

--- a/Sources/Tabman/Bar/BarItem/TMBarItem.swift
+++ b/Sources/Tabman/Bar/BarItem/TMBarItem.swift
@@ -11,6 +11,10 @@ import UIKit
 /// Definition of an item that can be displayed in a `TMBar`.
 ///
 /// Properties of a `TMBarItemable` are optionally displayed in a `TMBar` depending on the layout / configuration.
+///
+/// Tabman adds extensions to UIKit components to natively support `TMBarItemable`, such as `UINavigationItem` and
+/// `UITabBarItem`. Therefore for example, simply returning a `UIViewController` `navigationItem` as a `TMBarItemable` is
+/// fully supported.
 public protocol TMBarItemable: class {
     
     /// Title of the item.

--- a/Sources/Tabman/Bar/BarItem/UIKit+TMBarItemable.swift
+++ b/Sources/Tabman/Bar/BarItem/UIKit+TMBarItemable.swift
@@ -19,11 +19,3 @@ extension UINavigationItem: TMBarItemable {
 /// :nodoc:
 extension UITabBarItem: TMBarItemable {
 }
-
-/// :nodoc:
-extension UIViewController: TMBarItemable {
-    
-    public var image: UIImage? {
-        return tabBarItem.image
-    }
-}


### PR DESCRIPTION
Removes the `UIViewController` extension conforming to `TMBarItemable`, which has the potential to cause API clashes with the `.image` property. Also updates the docs to reflect the latest updates