### PR TITLE
Add public initializer for TMAnimation

### DIFF
--- a/Sources/Tabman/Bar/TMAnimation.swift
+++ b/Sources/Tabman/Bar/TMAnimation.swift
@@ -14,4 +14,9 @@ public struct TMAnimation {
     public let isEnabled: Bool
     /// Duration of the animation in seconds.
     public let duration: TimeInterval
+
+    public init(isEnabled: Bool, duration: TimeInterval) {
+        self.isEnabled = isEnabled
+        self.duration = duration
+    }
 }


### PR DESCRIPTION
From the Swift Documentation:

> ### Default Memberwise Initializers for Structure Types 
> The default memberwise initializer for a structure type is considered private if any of the structure’s stored properties are private. Otherwise, the initializer has an access level of internal.
> 
> As with the default initializer above, if you want a public structure type to be initializable with a memberwise initializer when used in another module, you must provide a public memberwise initializer yourself as part of the type’s definition.

This makes it possible to create an instance of TMAnimation from outside the module.

In my app, I am creating a TMBar outside of a TabmanViewController, and in order to call bar.update(for:capacity:direction:animation:), I ned to be able to create an instance of TMAnimation, which is only possible if TMAnimation has a public initializer.