### PR TITLE
Fix typo of TMBarDataSource in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ class TabViewController: TabmanViewController {
 4) Configure your data sources.
 
 ```swift
-extension TabViewController: PageboyViewControllerDataSource, BarDataSource {
+extension TabViewController: PageboyViewControllerDataSource, TMBarDataSource {
 
     func numberOfViewControllers(in pageboyViewController: PageboyViewController) -> Int {
         return viewControllers.count


### PR DESCRIPTION
```BarDataSource``` doesn't exist, I think ```TMBarDataSource``` is more appropriate.