### PR TITLE
Improve Access Controls

### DIFF
--- a/Sources/Tabman/Bar/BarButton/TMBarButton.swift
+++ b/Sources/Tabman/Bar/BarButton/TMBarButton.swift
@@ -39,7 +39,7 @@ open class TMBarButton: UIControl {
     // MARK: Customization
     
     /// Content inset of the button contents.
-    public var contentInset: UIEdgeInsets = .zero {
+    open var contentInset: UIEdgeInsets = .zero {
         didSet {
             contentViewLeading.constant = contentInset.left
             contentViewTop.constant = contentInset.top

--- a/Sources/Tabman/Bar/BarIndicator/TMBarIndicator.swift
+++ b/Sources/Tabman/Bar/BarIndicator/TMBarIndicator.swift
@@ -49,7 +49,7 @@ open class TMBarIndicator: UIView, TMTransitionStyleable {
     /// Whether the indicator should display progressively, traversing page indexes as visible progress.
     open var isProgressive: Bool = false
     /// Style of transition to use when updating the indicator.
-    open var transitionStyle: TMTransitionStyle = .progressive
+    public var transitionStyle: TMTransitionStyle = .progressive
     
     // MARK: Init
     

--- a/Sources/Tabman/Bar/BarIndicator/TMBarIndicator.swift
+++ b/Sources/Tabman/Bar/BarIndicator/TMBarIndicator.swift
@@ -45,11 +45,11 @@ open class TMBarIndicator: UIView, TMTransitionStyleable {
      /// - `.none`: Don't do anything.
      ///
      /// Defaults to `.bounce`.
-    public var overscrollBehavior: OverscrollBehavior = .bounce
+    open var overscrollBehavior: OverscrollBehavior = .bounce
     /// Whether the indicator should display progressively, traversing page indexes as visible progress.
-    public var isProgressive: Bool = false
+    open var isProgressive: Bool = false
     /// Style of transition to use when updating the indicator.
-    public var transitionStyle: TMTransitionStyle = .progressive
+    open var transitionStyle: TMTransitionStyle = .progressive
     
     // MARK: Init
     
@@ -74,6 +74,6 @@ open class TMBarIndicator: UIView, TMTransitionStyleable {
     
     // MARK: Lifecycle
     
-    public func layout(in view: UIView) {
+    open func layout(in view: UIView) {
     }
 }

--- a/Sources/Tabman/Bar/BarIndicator/Types/TMBlockBarIndicator.swift
+++ b/Sources/Tabman/Bar/BarIndicator/Types/TMBlockBarIndicator.swift
@@ -35,7 +35,7 @@ open class TMBlockBarIndicator: TMBarIndicator {
     /// - eliptical: Corners are completely circular.
     ///
     /// Default: `.square`.
-    public var cornerStyle: CornerStyle = .square {
+    open var cornerStyle: CornerStyle = .square {
         didSet {
             setNeedsLayout()
         }

--- a/Sources/Tabman/Bar/BarIndicator/Types/TMBlockBarIndicator.swift
+++ b/Sources/Tabman/Bar/BarIndicator/Types/TMBlockBarIndicator.swift
@@ -43,7 +43,7 @@ open class TMBlockBarIndicator: TMBarIndicator {
     
     // MARK: Lifecycle
     
-    public override func layout(in view: UIView) {
+    open override func layout(in view: UIView) {
         super.layout(in: view)
         
         self.backgroundColor = tintColor.withAlphaComponent(0.25)

--- a/Sources/Tabman/Bar/BarIndicator/Types/TMChevronBarIndicator.swift
+++ b/Sources/Tabman/Bar/BarIndicator/Types/TMChevronBarIndicator.swift
@@ -41,7 +41,7 @@ open class TMChevronBarIndicator: TMBarIndicator {
     /// - medium: (14 x 12pt)
     /// - large: (20 x 16pt)
     /// - custom: A custom size.
-    public var size: Size = .medium {
+    open var size: Size = .medium {
         didSet {
             guard size.rawValue != oldValue.rawValue else {
                 return

--- a/Sources/Tabman/Bar/BarIndicator/Types/TMChevronBarIndicator.swift
+++ b/Sources/Tabman/Bar/BarIndicator/Types/TMChevronBarIndicator.swift
@@ -58,7 +58,7 @@ open class TMChevronBarIndicator: TMBarIndicator {
     
     // MARK: Lifecycle
     
-    public override func layout(in view: UIView) {
+    open override func layout(in view: UIView) {
         super.layout(in: view)
         
         view.addSubview(chevronContainer)

--- a/Sources/Tabman/Bar/BarIndicator/Types/TMDotBarIndicator.swift
+++ b/Sources/Tabman/Bar/BarIndicator/Types/TMDotBarIndicator.swift
@@ -51,7 +51,7 @@ open class TMDotBarIndicator: TMBarIndicator {
     
     // MARK: Lifecycle
     
-    public override func layout(in view: UIView) {
+    open override func layout(in view: UIView) {
         super.layout(in: view)
         
         view.addSubview(dotContainer)

--- a/Sources/Tabman/Bar/BarIndicator/Types/TMDotBarIndicator.swift
+++ b/Sources/Tabman/Bar/BarIndicator/Types/TMDotBarIndicator.swift
@@ -34,7 +34,7 @@ open class TMDotBarIndicator: TMBarIndicator {
     
     // MARK: Customization
     
-    public var size: Size = .medium {
+    open var size: Size = .medium {
         didSet {
             guard size.rawValue != oldValue.rawValue else {
                 return

--- a/Sources/Tabman/Bar/BarIndicator/Types/TMLineBarIndicator.swift
+++ b/Sources/Tabman/Bar/BarIndicator/Types/TMLineBarIndicator.swift
@@ -73,7 +73,7 @@ open class TMLineBarIndicator: TMBarIndicator {
     
     // MARK: Lifecycle
     
-    public override func layout(in view: UIView) {
+    open override func layout(in view: UIView) {
         super.layout(in: view)
         
         let heightConstraint = heightAnchor.constraint(equalToConstant: weight.rawValue)

--- a/Sources/Tabman/Bar/BarIndicator/Types/TMLineBarIndicator.swift
+++ b/Sources/Tabman/Bar/BarIndicator/Types/TMLineBarIndicator.swift
@@ -51,7 +51,7 @@ open class TMLineBarIndicator: TMBarIndicator {
     /// - custom: Custom weight.
     ///
     /// Default: `.medium`
-    public var weight: Weight = .medium {
+    open var weight: Weight = .medium {
         didSet {
             weightConstraint?.constant = weight.rawValue
             setNeedsLayout()
@@ -65,7 +65,7 @@ open class TMLineBarIndicator: TMBarIndicator {
     /// - eliptical: Corners are completely circular.
     ///
     /// Default: `.square`.
-    public var cornerStyle: CornerStyle = .square {
+    open var cornerStyle: CornerStyle = .square {
         didSet {
             setNeedsLayout()
         }

--- a/Sources/Tabman/Bar/BarLayout/TMBarLayout.swift
+++ b/Sources/Tabman/Bar/BarLayout/TMBarLayout.swift
@@ -54,7 +54,7 @@ open class TMBarLayout: TMBarViewFocusProvider, TMTransitionStyleable {
         }
     }
     /// Inset to apply to the outside of the layout.
-    public var contentInset: UIEdgeInsets {
+    open var contentInset: UIEdgeInsets {
         set {
             insetGuides.insets = newValue
             parent.contentInset = newValue


### PR DESCRIPTION
#367 Some access controls were incorrectly `public` instead of `open` causing issues with overriding and. extensibility.