### PR TITLE
Feature: custom auto insetting

### DIFF
--- a/Sources/Tabman/TabmanViewController+Insets.swift
+++ b/Sources/Tabman/TabmanViewController+Insets.swift
@@ -27,27 +27,34 @@ public extension TabmanViewController {
         public let barInsets: UIEdgeInsets
         
         /// Inset specification for AutoInsetter.
-        internal let spec: InsetsSpec
+        internal var spec: AutoInsetSpec {
+            return InsetsSpec(allRequiredInsets: UIEdgeInsets(top: safeAreaInsets.top + barInsets.top,
+                                                              left: safeAreaInsets.left + barInsets.left,
+                                                              bottom: safeAreaInsets.bottom + barInsets.bottom,
+                                                              right: safeAreaInsets.right + barInsets.right),
+                              additionalRequiredInsets: barInsets)
+        }
         
         // MARK: Init
         
         private init(tabmanViewController: TabmanViewController) {
-            self.safeAreaInsets = Insets.makeSafeAreaInsets(for: tabmanViewController)
-            self.barInsets = UIEdgeInsets(top: tabmanViewController.topBarContainer.bounds.size.height,
-                                          left: 0.0,
-                                          bottom: tabmanViewController.bottomBarContainer.bounds.size.height,
-                                          right: 0.0)
+            let safeAreaInsets = Insets.makeSafeAreaInsets(for: tabmanViewController)
+            let barInsets = UIEdgeInsets(top: tabmanViewController.topBarContainer.bounds.size.height,
+                                         left: 0.0,
+                                         bottom: tabmanViewController.bottomBarContainer.bounds.size.height,
+                                         right: 0.0)
             
-            self.spec = InsetsSpec(allRequiredInsets: UIEdgeInsets(top: safeAreaInsets.top + barInsets.top,
-                                                                   left: safeAreaInsets.left + barInsets.left,
-                                                                   bottom: safeAreaInsets.bottom + barInsets.bottom,
-                                                                   right: safeAreaInsets.right + barInsets.right),
-                                   additionalRequiredInsets: barInsets)
+            self.init(barInsets: barInsets, safeAreaInsets: safeAreaInsets)
+        }
+        
+        public init(barInsets: UIEdgeInsets, safeAreaInsets: UIEdgeInsets) {
+            self.barInsets = barInsets
+            self.safeAreaInsets = safeAreaInsets
         }
         
         // MARK: Utility
         
-        private static func makeSafeAreaInsets(for viewController: UIViewController) -> UIEdgeInsets {
+        public static func makeSafeAreaInsets(for viewController: UIViewController) -> UIEdgeInsets {
             if #available(iOS 11, *) {
                 return viewController.view.safeAreaInsets
             } else {

--- a/Sources/Tabman/TabmanViewController.swift
+++ b/Sources/Tabman/TabmanViewController.swift
@@ -70,6 +70,17 @@ open class TabmanViewController: PageboyViewController, PageboyViewControllerDel
     private var barLayoutGuideTop: NSLayoutConstraint?
     private var barLayoutGuideBottom: NSLayoutConstraint?
     
+    /// A method for calculating insets that are required to layout content between the bars
+    /// that have been added.
+    ///
+    /// One can override this method with their own implementation for custom bar inset calculation, to
+    /// take advantage of automatic insets updates for all Tabman's pages during its lifecycle.
+    ///
+    /// - Returns: information about required insets for current state.
+    open func calculateRequiredInsets() -> Insets {
+        return Insets.for(tabmanViewController: self)
+    }
+    
     // MARK: Init
     
     public override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
@@ -344,7 +355,7 @@ internal extension TabmanViewController {
     }
     
     func setNeedsInsetsUpdate(to viewController: UIViewController?) {
-        let insets = Insets.for(tabmanViewController: self)
+        let insets = calculateRequiredInsets()
         self.requiredInsets = insets
         
         barLayoutGuideTop?.constant = insets.spec.allRequiredInsets.top


### PR DESCRIPTION
I love the way that TabmanViewController knows when it needs to update the insets during its lifecycle, I just wanted to customize the calculation of the insets inside, so that they will reflect my custom view's (which a tab bar is embedded into) size. 

As a result, my modification allows for easier customization when embedding a tab bar into custom views, while not breaking any current behavior / APIs.

This pull request proposes a solution for an improvement discussed in #391 