### PR TITLE
Accessibility

### DIFF
--- a/Sources/Tabman/Bar/BarButton/TMBarButton.swift
+++ b/Sources/Tabman/Bar/BarButton/TMBarButton.swift
@@ -98,6 +98,10 @@ open class TMBarButton: UIControl {
         
         layout(in: contentView)
         layoutBadge(badge, in: contentView)
+
+        accessibilityLabel = item.accessibilityLabel
+        accessibilityHint = item.accessibilityHint
+        accessibilityTraits = [.button]
     }
     
     // MARK: Layout
@@ -158,6 +162,15 @@ open class TMBarButton: UIControl {
         let alpha = minimumAlpha + (selectionState.rawValue * minimumAlpha)
         
         self.alpha = alpha
+
+        switch selectionState {
+        case .selected:
+            accessibilityTraits.insert(.selected)
+        case .unselected:
+            accessibilityTraits.remove(.selected)
+        default:
+            break
+        }
     }
 }
 

--- a/Sources/Tabman/Bar/BarButton/TMBarButton.swift
+++ b/Sources/Tabman/Bar/BarButton/TMBarButton.swift
@@ -99,9 +99,10 @@ open class TMBarButton: UIControl {
         layout(in: contentView)
         layoutBadge(badge, in: contentView)
 
-        accessibilityLabel = item.accessibilityLabel
+        accessibilityLabel = item.accessibilityLabel ?? item.title
         accessibilityHint = item.accessibilityHint
         accessibilityTraits = [.button]
+        isAccessibilityElement = true
     }
     
     // MARK: Layout

--- a/Sources/Tabman/Bar/BarButton/Types/TMLabelBarButton.swift
+++ b/Sources/Tabman/Bar/BarButton/Types/TMLabelBarButton.swift
@@ -156,6 +156,7 @@ open class TMLabelBarButton: TMBarButton {
     }
     
     open override func update(for selectionState: TMBarButton.SelectionState) {
+        super.update(for: selectionState)
         
         let transitionColor = tintColor.interpolate(with: selectedTintColor,
                                                     percent: selectionState.rawValue)

--- a/Sources/Tabman/Bar/BarItem/TMBarItem.swift
+++ b/Sources/Tabman/Bar/BarItem/TMBarItem.swift
@@ -26,6 +26,12 @@ public protocol TMBarItemable: class {
     
     /// Badge value to display.
     var badgeValue: String? { get set }
+
+    /// Returns a short description of the button.
+    var accessibilityLabel: String? { get set }
+
+    /// A brief description of the result of performing an action on the accessibility element, in a localized string.
+    var accessibilityHint: String? { get set }
     
     /// Inform the bar that the item has been updated.
     ///
@@ -45,6 +51,7 @@ extension TMBarItemable {
 
 /// Default `TMBarItemable` that can be displayed in a `TMBar`.
 public final class TMBarItem: TMBarItemable {
+
     
     // MARK: Properties
     
@@ -60,6 +67,18 @@ public final class TMBarItem: TMBarItemable {
     }
     
     public var badgeValue: String? {
+        didSet {
+            setNeedsUpdate()
+        }
+    }
+
+    public var accessibilityLabel: String? {
+        didSet {
+            setNeedsUpdate()
+        }
+    }
+
+    public var accessibilityHint: String? {
         didSet {
             setNeedsUpdate()
         }

--- a/Sources/Tabman/Bar/BarItem/TMBarItem.swift
+++ b/Sources/Tabman/Bar/BarItem/TMBarItem.swift
@@ -83,6 +83,8 @@ public final class TMBarItem: TMBarItemable {
             setNeedsUpdate()
         }
     }
+
+    public var isAccessibilityElement: Bool { return true }
         
     // MARK: Init
     

--- a/Sources/Tabman/Bar/BarView/TMBarView.swift
+++ b/Sources/Tabman/Bar/BarView/TMBarView.swift
@@ -169,6 +169,9 @@ open class TMBarView<Layout: TMBarLayout, Button: TMBarButton, Indicator: TMBarI
         buttons.interactionHandler = self
         scrollHandler.delegate = self
         scrollView.gestureDelegate = self
+        if #available(iOSApplicationExtension 10.0, *) {
+            accessibilityTraits = [.tabBar]
+        }
         layout(in: self)
         
         NotificationCenter.default.addObserver(self,
@@ -301,6 +304,23 @@ open class TMBarView<Layout: TMBarLayout, Button: TMBarButton, Indicator: TMBarI
             button.populate(for: item)
             self.reloadIndicatorPosition()
         }, completion: nil)
+    }
+
+    // MARK: UIAccessibilityContainer
+
+    override open func accessibilityElementCount() -> Int {
+        return buttons.all.count
+    }
+
+    override open func accessibilityElement(at index: Int) -> Any? {
+        return buttons.all[index]
+    }
+
+    open override func index(ofAccessibilityElement element: Any) -> Int {
+        guard let item = element as? Button else {
+            return 0
+        }
+        return buttons.all.firstIndex(of: item) ?? 0
     }
 }
 


### PR DESCRIPTION
Fixes #399

Originally I just wanted to add `accessibilityLabel` to Tab Buttons to use them in UI Tests.However, when I looked into this I found that Tabman was not accessible at all. 

Whit these changes, Tabman is now accessibly without any changes required by Users of Tabman.

The most important change was for `TMBarView` to implement the (informal) (UIAccessibilityContainer Protocol)[https://developer.apple.com/documentation/uikit/accessibility/uiaccessibilitycontainer], which basically just needs to return the elements in the container (in this case the buttons).