### PR TITLE
Refactor default button transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Released on TBD
 #### Added
 - Ability to override automatic inset values via `calculateRequiredInsets()` on `TabmanViewController`.
      - by [WingedDoom](https://github.com/WingedDoom)
+- [#404](https://github.com/uias/Tabman/issues/404) `adjustsAlphaOnSelection` to `TMBarButton`.
 
 #### Updated
 - Make `TMBarItem` `open`.

--- a/Sources/Tabman/Bar/BarButton/TMBarButton.swift
+++ b/Sources/Tabman/Bar/BarButton/TMBarButton.swift
@@ -59,6 +59,12 @@ open class TMBarButton: UIControl {
     /// Badge View
     public let badge = TMBadgeView()
     
+    /// Whether the button should fade its alpha value when it is unselected.
+    ///
+    /// If enabled the button will interpolate between a minumum alpha of 0.5 and 1.0
+    /// depending on the current `selectionState`.
+    open var fadesWhenUnselected: Bool = true
+    
     // MARK: State
     
     /// Selection state of the button.
@@ -168,10 +174,13 @@ open class TMBarButton: UIControl {
     ///
     /// - Parameter selectionState: Selection state.
     open func update(for selectionState: SelectionState) {
-        let minimumAlpha: CGFloat = 0.5
-        let alpha = minimumAlpha + (selectionState.rawValue * minimumAlpha)
         
-        self.alpha = alpha
+        // Perform alpha update if enabled.
+        if fadesWhenUnselected {
+            let minimumAlpha: CGFloat = 0.5
+            let alpha = minimumAlpha + (selectionState.rawValue * minimumAlpha)
+            self.alpha = alpha
+        }
 
         switch selectionState {
         case .selected:

--- a/Sources/Tabman/Bar/BarButton/TMBarButton.swift
+++ b/Sources/Tabman/Bar/BarButton/TMBarButton.swift
@@ -63,7 +63,7 @@ open class TMBarButton: UIControl {
     ///
     /// If enabled the button will interpolate between a minumum alpha of 0.5 and 1.0
     /// depending on the current `selectionState`.
-    open var fadesWhenUnselected: Bool = true
+    open var adjustsAlphaOnSelection: Bool = true
     
     // MARK: State
     
@@ -176,7 +176,7 @@ open class TMBarButton: UIControl {
     open func update(for selectionState: SelectionState) {
         
         // Perform alpha update if enabled.
-        if fadesWhenUnselected {
+        if adjustsAlphaOnSelection {
             let minimumAlpha: CGFloat = 0.5
             let alpha = minimumAlpha + (selectionState.rawValue * minimumAlpha)
             self.alpha = alpha

--- a/Sources/Tabman/Bar/BarButton/Types/TMLabelBarButton.swift
+++ b/Sources/Tabman/Bar/BarButton/Types/TMLabelBarButton.swift
@@ -119,7 +119,7 @@ open class TMLabelBarButton: TMBarButton {
         label.textAlignment = .center
         label.setContentCompressionResistancePriority(.required, for: .vertical)
         
-        fadesWhenUnselected = false
+        adjustsAlphaOnSelection = false
         label.text = Defaults.text
         label.font = self.font
         selectedTintColor = tintColor

--- a/Sources/Tabman/Bar/BarButton/Types/TMLabelBarButton.swift
+++ b/Sources/Tabman/Bar/BarButton/Types/TMLabelBarButton.swift
@@ -119,6 +119,7 @@ open class TMLabelBarButton: TMBarButton {
         label.textAlignment = .center
         label.setContentCompressionResistancePriority(.required, for: .vertical)
         
+        fadesWhenUnselected = false
         label.text = Defaults.text
         label.font = self.font
         selectedTintColor = tintColor


### PR DESCRIPTION
#404 

Adds `adjustsAlphaOnSelection` to `TMBarButton` replacing the need for avoiding `super` calls to not use the default Alpha selection transition.