### PR TITLE
Fix constraints for TMTabItemBarButton

### DIFF
--- a/Sources/Tabman/Bar/BarButton/Types/TMTabItemBarButton.swift
+++ b/Sources/Tabman/Bar/BarButton/Types/TMTabItemBarButton.swift
@@ -91,6 +91,16 @@ open class TMTabItemBarButton: TMBarButton {
     }
     
     // MARK: Lifecycle
+
+    public required init(for item: TMBarItemable, intrinsicSuperview: UIView?) {
+        super.init(for: item, intrinsicSuperview: intrinsicSuperview)
+
+        makeComponentConstraints(for: UIDevice.current.orientation)
+    }
+
+    public required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
     
     open override func layout(in view: UIView) {
         super.layout(in: view)

--- a/Sources/Tabman/Bar/BarButton/Types/TMTabItemBarButton.swift
+++ b/Sources/Tabman/Bar/BarButton/Types/TMTabItemBarButton.swift
@@ -95,7 +95,9 @@ open class TMTabItemBarButton: TMBarButton {
     public required init(for item: TMBarItemable, intrinsicSuperview: UIView?) {
         super.init(for: item, intrinsicSuperview: intrinsicSuperview)
 
-        makeComponentConstraints(for: UIDevice.current.orientation)
+        if #available(iOS 13.0, *) {
+            makeComponentConstraints(for: UIDevice.current.orientation)
+        }
     }
 
     public required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
Since iOS 13 `traitCollectionDidChange(_:)` is not being called initially anymore in most of the cases. Instead, UIKit tries to predict a views' traitCollection based on the context (see https://useyourloaf.com/blog/predicting-size-classes-in-ios-13/) and only calls `traitCollectionDidChange(_:)` on subsequent changes.
Thus we can't use said method anymore for code which has to be executed upon starting the lifecycle.