### PR TITLE
Add contentInset support to badge view

### DIFF
--- a/Example/Tabman-Example/TabPageViewController.swift
+++ b/Example/Tabman-Example/TabPageViewController.swift
@@ -51,7 +51,6 @@ class TabPageViewController: TabmanViewController {
         bar.indicator.cornerStyle = .eliptical
         bar.fadesContentEdges = true
         bar.spacing = 16.0
-        bar.backgroundView.style = .clear
         
         // Add a '+' button the trailing end of the bar to insert more pages.
         let plusButton = CircularBarActionButton(action: .add)

--- a/Sources/Tabman/Bar/BarButton/Badge/TMBadgeView.swift
+++ b/Sources/Tabman/Bar/BarButton/Badge/TMBadgeView.swift
@@ -117,8 +117,9 @@ open class TMBadgeView: UIView {
         label.textAlignment = .center
         label.font = Defaults.font
         label.textColor = Defaults.textColor
-        tintColor = Defaults.tintColor
-        
+        tintColor = Defaults.tintColor        
+        clipsToBounds = true
+
         label.text = "."
         updateContentVisibility(for: nil)
     }

--- a/Sources/Tabman/Bar/BarButton/Badge/TMBadgeView.swift
+++ b/Sources/Tabman/Bar/BarButton/Badge/TMBadgeView.swift
@@ -25,6 +25,11 @@ open class TMBadgeView: UIView {
     private let contentView = UIView()
     private let label = UILabel()
     
+    private var labelLeading: NSLayoutConstraint!
+    private var labelTop: NSLayoutConstraint!
+    private var labelTrailing: NSLayoutConstraint!
+    private var labelBottom: NSLayoutConstraint!
+    
     /// Value to display.
     internal var value: String? {
         didSet {
@@ -64,6 +69,14 @@ open class TMBadgeView: UIView {
             contentView.backgroundColor = tintColor
         }
     }
+    /// Content Inset around the badge label.
+    ///
+    /// Defaults to `UIEdgeInsets(top: 2.0, left: 4.0, bottom: 2.0, right: 4.0)`.
+    open var contentInset: UIEdgeInsets = Defaults.contentInset {
+        didSet {
+            updateContentInset()
+        }
+    }
     
     // MARK: Init
     
@@ -88,15 +101,14 @@ open class TMBadgeView: UIView {
             bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
             ])
         
-        let contentInset = Defaults.contentInset
         contentView.addSubview(label)
         label.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            label.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: contentInset.left),
-            label.topAnchor.constraint(equalTo: contentView.topAnchor, constant: contentInset.top),
-            contentView.trailingAnchor.constraint(equalTo: label.trailingAnchor, constant: contentInset.right),
-            contentView.bottomAnchor.constraint(equalTo: label.bottomAnchor, constant: contentInset.bottom)
-            ])
+        
+        labelLeading = label.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: contentInset.left)
+        labelTop = label.topAnchor.constraint(equalTo: contentView.topAnchor, constant: contentInset.top)
+        labelTrailing = contentView.trailingAnchor.constraint(equalTo: label.trailingAnchor, constant: contentInset.right)
+        labelBottom = contentView.bottomAnchor.constraint(equalTo: label.bottomAnchor, constant: contentInset.bottom)
+        NSLayoutConstraint.activate([labelLeading, labelTop, labelTrailing, labelBottom])
         
         NSLayoutConstraint.activate([
             widthAnchor.constraint(greaterThanOrEqualTo: heightAnchor)
@@ -118,8 +130,26 @@ open class TMBadgeView: UIView {
         
         contentView.layer.cornerRadius = bounds.size.height / 2.0
     }
+}
+
+// MARK: - Constraints
+extension TMBadgeView {
     
-    // MARK: Animations
+    private func updateContentInset() {
+        guard let labelLeading = labelLeading else {
+            assertionFailure("Trying to update contentInset before constraints have been set")
+            return
+        }
+        
+        labelLeading.constant = contentInset.left
+        labelTop.constant = contentInset.top
+        labelTrailing.constant = contentInset.right
+        labelBottom.constant = contentInset.bottom
+    }
+}
+
+// MARK: - Animations
+extension TMBadgeView {
     
     private func updateContentVisibility(for value: String?) {
         switch value {

--- a/Sources/Tabman/Bar/BarButton/Types/TMLabelBarButton.swift
+++ b/Sources/Tabman/Bar/BarButton/Types/TMLabelBarButton.swift
@@ -103,8 +103,9 @@ open class TMLabelBarButton: TMBarButton {
         let badgeContainerWidth = badgeContainer.widthAnchor.constraint(equalToConstant: 0.0)
         let constraints = [
             label.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            label.topAnchor.constraint(equalTo: view.topAnchor),
-            view.bottomAnchor.constraint(equalTo: label.bottomAnchor),
+            label.topAnchor.constraint(greaterThanOrEqualTo: view.topAnchor),
+            view.bottomAnchor.constraint(greaterThanOrEqualTo: label.bottomAnchor),
+            label.centerYAnchor.constraint(equalTo: view.centerYAnchor),
             badgeContainerLeading,
             badgeContainer.topAnchor.constraint(equalTo: view.topAnchor),
             view.trailingAnchor.constraint(equalTo: badgeContainer.trailingAnchor),

--- a/Sources/Tabman/Bar/BarButton/Types/TMLabelBarButton.swift
+++ b/Sources/Tabman/Bar/BarButton/Types/TMLabelBarButton.swift
@@ -137,8 +137,9 @@ open class TMLabelBarButton: TMBarButton {
         badge.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             badge.leadingAnchor.constraint(equalTo: badgeContainer.leadingAnchor),
-            badge.topAnchor.constraint(equalTo: badgeContainer.topAnchor),
-            badgeContainer.bottomAnchor.constraint(equalTo: badge.bottomAnchor)
+            badge.topAnchor.constraint(greaterThanOrEqualTo: badgeContainer.topAnchor),
+            badgeContainer.bottomAnchor.constraint(greaterThanOrEqualTo: badge.bottomAnchor),
+            badge.centerYAnchor.constraint(equalTo: badgeContainer.centerYAnchor)
             ])
     }
     

--- a/Sources/Tabman/Bar/BarExtensions/SystemBar/TMSystemBar.swift
+++ b/Sources/Tabman/Bar/BarExtensions/SystemBar/TMSystemBar.swift
@@ -153,13 +153,13 @@ public final class TMSystemBar: UIView {
         let isNavigationBarNotVisible = viewController.navigationController?.isNavigationBarHidden != false
         
         let relativeFrame = viewController.view.convert(self.frame, from: superview)
-        if relativeFrame.origin.y == safeAreaInsets.top, isNavigationBarNotVisible { // Pin to top anchor
+        if ceil(relativeFrame.origin.y) == safeAreaInsets.top, isNavigationBarNotVisible { // Pin to top anchor
             constraints.append(contentsOf: [
                 extendingView.topAnchor.constraint(equalTo: viewController.view.topAnchor),
                 extendingView.bottomAnchor.constraint(equalTo: bottomAnchor)
                 ])
             contentView.addArrangedSubview(makeSeparatorView())
-        } else if relativeFrame.maxY == (viewController.view.bounds.size.height - safeAreaInsets.bottom) { // Pin to bottom anchor
+        } else if ceil(relativeFrame.maxY) == (viewController.view.bounds.size.height - safeAreaInsets.bottom) { // Pin to bottom anchor
             constraints.append(contentsOf: [
                 extendingView.topAnchor.constraint(equalTo: topAnchor),
                 extendingView.bottomAnchor.constraint(equalTo: viewController.view.bottomAnchor)


### PR DESCRIPTION
Exposes and adds support for custom `contentInset` to `TMBadgeView`. 

- Fixes constraint where badge would be fixed to button height of `TMLabelBarButton`.

#459 