### PR TITLE
Fixed the centered alignment on TMBarView

### DIFF
--- a/Sources/Tabman/Bar/BarView/TMBarView.swift
+++ b/Sources/Tabman/Bar/BarView/TMBarView.swift
@@ -272,29 +272,40 @@ open class TMBarView<Layout: TMBarLayout, Button: TMBarButton, Indicator: TMBarI
     }
 
     private func updateScrollViewContentInset() {
+        let leftAlignmentInset: CGFloat
+        let rightAlignmentInset: CGFloat
         
-        let alignmentInset: CGFloat
         switch alignment {
         case .leading:
-            alignmentInset = 0.0
+            leftAlignmentInset = 0.0
+            rightAlignmentInset = 0.0
         case .center:
-            let buttonWidth = (buttons.all.first?.bounds.size.width ?? 0.0) / 2.0
+            // Left Side Inset
+            let leftButtonWidth = (buttons.all.first?.bounds.size.width ?? 0.0) / 2.0
             var width = bounds.size.width / 2
             if #available(iOS 11, *) {
                 width -= safeAreaInsets.left
             }
-            alignmentInset = width - buttonWidth
+            leftAlignmentInset = width - leftButtonWidth
+            
+            // Right Side Inset
+            let rightButtonWidth = (buttons.all.last?.bounds.size.width ?? 0.0) / 2.0
+            width = bounds.size.width / 2
+            if #available(iOS 11, *) {
+                width -= safeAreaInsets.right
+            }
+            rightAlignmentInset = width - rightButtonWidth
         case .trailing:
             let buttonWidth = (buttons.all.first?.bounds.size.width ?? 0.0)
             var width = bounds.size.width
             if #available(iOS 11, *) {
                 width -= safeAreaInsets.left
             }
-            alignmentInset = width - buttonWidth
+            leftAlignmentInset = width - buttonWidth
+            rightAlignmentInset = 0.0
         }
         
-        let rightInset = alignment == .center ? alignmentInset + contentInset.right : contentInset.right
-        let sanitizedContentInset = UIEdgeInsets(top: 0.0, left: alignmentInset + contentInset.left, bottom: 0.0, right: rightInset)
+        let sanitizedContentInset = UIEdgeInsets(top: 0.0, left: leftAlignmentInset + contentInset.left, bottom: 0.0, right: rightAlignmentInset + contentInset.right)
         scrollView.contentInset = sanitizedContentInset
         scrollView.contentOffset.x -= sanitizedContentInset.left
         

--- a/Sources/Tabman/Bar/BarView/TMBarView.swift
+++ b/Sources/Tabman/Bar/BarView/TMBarView.swift
@@ -293,7 +293,8 @@ open class TMBarView<Layout: TMBarLayout, Button: TMBarButton, Indicator: TMBarI
             alignmentInset = width - buttonWidth
         }
         
-        let sanitizedContentInset = UIEdgeInsets(top: 0.0, left: alignmentInset + contentInset.left, bottom: 0.0, right: contentInset.right)
+        let rightInset = alignment == .center ? alignmentInset + contentInset.right : contentInset.right
+        let sanitizedContentInset = UIEdgeInsets(top: 0.0, left: alignmentInset + contentInset.left, bottom: 0.0, right: rightInset)
         scrollView.contentInset = sanitizedContentInset
         scrollView.contentOffset.x -= sanitizedContentInset.left
         


### PR DESCRIPTION
This fixes the alignment issue noted here:  #467 

Overview: The implementation of the "centered alignment" does not match what it previously was in older versions. Currently when you select centered, and depending on how many buttons you have, the first few are centered but the last two are not.

This ensures there is an equal amount of space on both sides.