### PR TITLE
Add vertical alignment to TMLabelBarButton

### DIFF
--- a/Example/Tabman-Example/TabPageViewController.swift
+++ b/Example/Tabman-Example/TabPageViewController.swift
@@ -58,10 +58,22 @@ class TabPageViewController: TabmanViewController {
         plusButton.tintColor = .white
         bar.rightAccessoryView = plusButton
         
+        let container = UIView()
+        view.addSubview(container)
+        container.translatesAutoresizingMaskIntoConstraints = false
+        if #available(iOS 11, *) {
+            NSLayoutConstraint.activate([
+                container.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                container.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+                view.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+                container.heightAnchor.constraint(equalToConstant: 100.0)
+            ])
+        }
+        
         // Add the bar to the view controller - wrapping it in a `TMSystemBar`.
-        addBar(bar.systemBar(),
+        addBar(bar,
                dataSource: self,
-               at: .top)
+               at: .custom(view: container, layout: nil))
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -72,6 +84,7 @@ class TabPageViewController: TabmanViewController {
         bar.buttons.customize { (button) in
             button.selectedTintColor = tintColor
             button.tintColor = tintColor.withAlphaComponent(0.4)
+            button.verticalAlignment = .top
         }
         bar.indicator.tintColor = tintColor
     }

--- a/Example/Tabman-Example/TabPageViewController.swift
+++ b/Example/Tabman-Example/TabPageViewController.swift
@@ -58,22 +58,10 @@ class TabPageViewController: TabmanViewController {
         plusButton.tintColor = .white
         bar.rightAccessoryView = plusButton
         
-        let container = UIView()
-        view.addSubview(container)
-        container.translatesAutoresizingMaskIntoConstraints = false
-        if #available(iOS 11, *) {
-            NSLayoutConstraint.activate([
-                container.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-                container.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-                view.trailingAnchor.constraint(equalTo: container.trailingAnchor),
-                container.heightAnchor.constraint(equalToConstant: 100.0)
-            ])
-        }
-        
         // Add the bar to the view controller - wrapping it in a `TMSystemBar`.
-        addBar(bar,
+        addBar(bar.systemBar(),
                dataSource: self,
-               at: .custom(view: container, layout: nil))
+               at: .top)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -84,7 +72,6 @@ class TabPageViewController: TabmanViewController {
         bar.buttons.customize { (button) in
             button.selectedTintColor = tintColor
             button.tintColor = tintColor.withAlphaComponent(0.4)
-            button.verticalAlignment = .top
         }
         bar.indicator.tintColor = tintColor
     }

--- a/Sources/Tabman/Bar/BarButton/Types/TMLabelBarButton.swift
+++ b/Sources/Tabman/Bar/BarButton/Types/TMLabelBarButton.swift
@@ -103,7 +103,7 @@ open class TMLabelBarButton: TMBarButton {
         }
     }
     
-    /// How to vertically align the label within the button.
+    /// How to vertically align the label within the button. Defaults to `.center`.
     ///
     /// - Note: This will only apply when the button is larger than
     /// the required intrinsic height. If the bar sizes itself intrinsically,

--- a/Sources/Tabman/Bar/BarButton/Types/TMLabelBarButton.swift
+++ b/Sources/Tabman/Bar/BarButton/Types/TMLabelBarButton.swift
@@ -163,8 +163,6 @@ open class TMLabelBarButton: TMBarButton {
         selectedTintColor = .systemBlue
         contentInset = Defaults.contentInset
         
-        backgroundColor = .red
-        
         calculateFontIntrinsicContentSize(for: label.text)
     }
     

--- a/Sources/Tabman/Bar/BarButton/Types/TMLabelBarButton.swift
+++ b/Sources/Tabman/Bar/BarButton/Types/TMLabelBarButton.swift
@@ -22,6 +22,14 @@ open class TMLabelBarButton: TMBarButton {
         static let badgeLeadingInset: CGFloat = 8.0
     }
     
+    // MARK: Types
+    
+    public enum VerticalAlignment {
+        case center
+        case top
+        case bottom
+    }
+    
     // MARK: Properties
     
     open override var intrinsicContentSize: CGSize {
@@ -90,6 +98,15 @@ open class TMLabelBarButton: TMBarButton {
         }
     }
     
+    open var verticalAlignment: VerticalAlignment = .center {
+        didSet {
+            updateAlignmentConstraints()
+        }
+    }
+    private var labelTopConstraint: NSLayoutConstraint?
+    private var labelCenterConstraint: NSLayoutConstraint?
+    private var labelBottomConstraint: NSLayoutConstraint?
+    
     // MARK: Lifecycle
     
     open override func layout(in view: UIView) {
@@ -101,11 +118,12 @@ open class TMLabelBarButton: TMBarButton {
         badgeContainer.translatesAutoresizingMaskIntoConstraints = false
         let badgeContainerLeading = badgeContainer.leadingAnchor.constraint(equalTo: label.trailingAnchor)
         let badgeContainerWidth = badgeContainer.widthAnchor.constraint(equalToConstant: 0.0)
+        let labelCenterConstraint = label.centerYAnchor.constraint(equalTo: view.centerYAnchor)
         let constraints = [
             label.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             label.topAnchor.constraint(greaterThanOrEqualTo: view.topAnchor),
             view.bottomAnchor.constraint(greaterThanOrEqualTo: label.bottomAnchor),
-            label.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            labelCenterConstraint,
             badgeContainerLeading,
             badgeContainer.topAnchor.constraint(equalTo: view.topAnchor),
             view.trailingAnchor.constraint(equalTo: badgeContainer.trailingAnchor),
@@ -114,6 +132,10 @@ open class TMLabelBarButton: TMBarButton {
         ]
         self.badgeContainerLeading = badgeContainerLeading
         self.badgeContainerWidth = badgeContainerWidth
+        
+        self.labelCenterConstraint = labelCenterConstraint
+        self.labelTopConstraint = label.topAnchor.constraint(equalTo: view.topAnchor)
+        self.labelBottomConstraint = view.bottomAnchor.constraint(equalTo: label.bottomAnchor)
         
         NSLayoutConstraint.activate(constraints)
         
@@ -130,6 +152,8 @@ open class TMLabelBarButton: TMBarButton {
         }
         selectedTintColor = .systemBlue
         contentInset = Defaults.contentInset
+        
+        backgroundColor = .red
         
         calculateFontIntrinsicContentSize(for: label.text)
     }
@@ -200,6 +224,23 @@ open class TMLabelBarButton: TMBarButton {
         let isBadgeVisible = badge.value != nil
         badgeContainerWidth?.constant =  isBadgeVisible ? badge.bounds.size.width : 0.0
         badgeContainerLeading?.constant = isBadgeVisible ? Defaults.badgeLeadingInset : 0.0
+    }
+    
+    private func updateAlignmentConstraints() {
+        switch verticalAlignment {
+        case .center:
+            labelCenterConstraint?.isActive = true
+            labelTopConstraint?.isActive = false
+            labelBottomConstraint?.isActive = false
+        case .top:
+            labelCenterConstraint?.isActive = false
+            labelTopConstraint?.isActive = true
+            labelBottomConstraint?.isActive = false
+        case .bottom:
+            labelCenterConstraint?.isActive = false
+            labelTopConstraint?.isActive = false
+            labelBottomConstraint?.isActive = true
+        }
     }
 }
 

--- a/Sources/Tabman/Bar/BarButton/Types/TMLabelBarButton.swift
+++ b/Sources/Tabman/Bar/BarButton/Types/TMLabelBarButton.swift
@@ -24,6 +24,11 @@ open class TMLabelBarButton: TMBarButton {
     
     // MARK: Types
     
+    /// Vertical alignment of the label within the bar button.
+    ///
+    /// - `.center`: Center the label vertically in the button.
+    /// - `.top`: Align the label with the top of the button.
+    /// - `.bottom`: Align the label with the bottom of the button.
     public enum VerticalAlignment {
         case center
         case top
@@ -98,6 +103,11 @@ open class TMLabelBarButton: TMBarButton {
         }
     }
     
+    /// How to vertically align the label within the button.
+    ///
+    /// - Note: This will only apply when the button is larger than
+    /// the required intrinsic height. If the bar sizes itself intrinsically,
+    /// setting this paramter will have no effect.
     open var verticalAlignment: VerticalAlignment = .center {
         didSet {
             updateAlignmentConstraints()


### PR DESCRIPTION
Adds `verticalAlignment` property to `TMLabelBarButton` to allow for customisation of the label vertical alignment within the button bounds.

*Note - this will only have an effect if the bounds of the button are vertically greater than the required intrinsic size of the label.*

**Center (Default)**
![Simulator Screen Shot - iPhone 11 Pro - 2020-01-03 at 14 01 05](https://user-images.githubusercontent.com/3515448/71727439-23145900-2e32-11ea-8dc7-5c1cbdb87477.png)

**Top**
![Simulator Screen Shot - iPhone 11 Pro - 2020-01-03 at 14 00 31](https://user-images.githubusercontent.com/3515448/71727445-290a3a00-2e32-11ea-855f-fffc022b1532.png)

**Bottom**
![Simulator Screen Shot - iPhone 11 Pro - 2020-01-03 at 14 01 14](https://user-images.githubusercontent.com/3515448/71727454-2e678480-2e32-11ea-91d7-c03792484a27.png)

Resolves #450