### PR TITLE
Excluded Tabman.h and info.plist in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
             name: "Tabman",
             dependencies: ["Pageboy"],
             path: ".",
+            exclude: ["Sources/Tabman/Tabman.h", "Sources/Tabman/Info.plist"],
             sources: ["Sources/Tabman"]),
         .testTarget(
             name: "TabmanTests",


### PR DESCRIPTION
#501 
This change was required to avoid the error :
...Tabman' contains mixed language source files; feature not supported
when including Tabman via swift package manager in Xcode 11.4