### PR TITLE
Fix RTL layout issue with semanticContentAttribute

### DIFF
--- a/Sources/Tabman/Bar/BarView/TMBarView.swift
+++ b/Sources/Tabman/Bar/BarView/TMBarView.swift
@@ -340,7 +340,7 @@ open class TMBarView<Layout: TMBarLayout, Button: TMBarButton, Indicator: TMBarI
         
         UIView.animate(withDuration: 0.2, delay: 0.0, options: .curveEaseIn, animations: {
             button.populate(for: item)
-            self.reloadIndicatorPosition()
+            self.updateIndicatorPosition()
         }, completion: nil)
     }
 
@@ -414,7 +414,7 @@ extension TMBarView: TMBar {
         UIView.performWithoutAnimation {
             layoutIfNeeded()
             updateScrollViewContentInset()
-            reloadIndicatorPosition()
+            updateIndicatorPosition()
         }
     }
     
@@ -526,7 +526,7 @@ extension TMBarView {
         return container
     }
     
-    private func reloadIndicatorPosition() {
+    private func updateIndicatorPosition() {
         guard let indicatedPosition = self.indicatedPosition else {
             return
         }
@@ -604,7 +604,7 @@ private extension TMBarView {
             rootContentStack.insertArrangedSubview(view, at: rootContentStack.arrangedSubviews.count)
         }
         
-        reloadIndicatorPosition()
+        updateIndicatorPosition()
     }
 }
 

--- a/Sources/Tabman/Bar/BarView/TMBarView.swift
+++ b/Sources/Tabman/Bar/BarView/TMBarView.swift
@@ -200,19 +200,13 @@ open class TMBarView<Layout: TMBarLayout, Button: TMBarButton, Indicator: TMBarI
     open override func layoutSubviews() {
         super.layoutSubviews()
         
-        UIView.performWithoutAnimation {
-            reloadIndicatorPosition()
-            updateEdgeFades(for: scrollView)
-        }
+        updateIndicatorForCurrentLayout()
     }
     
     open override func didMoveToWindow() {
         super.didMoveToWindow()
         
-        UIView.performWithoutAnimation {
-            reloadIndicatorPosition()
-            updateEdgeFades(for: scrollView)
-        }
+        updateIndicatorForCurrentLayout()
     }
     
     private func layout(in view: UIView) {
@@ -413,6 +407,10 @@ extension TMBarView: TMBar {
         }
         
         self.items = items
+        updateIndicatorForCurrentLayout()
+    }
+    
+    private func updateIndicatorForCurrentLayout() {
         UIView.performWithoutAnimation {
             layoutIfNeeded()
             updateScrollViewContentInset()

--- a/Sources/Tabman/Bar/BarView/TMBarView.swift
+++ b/Sources/Tabman/Bar/BarView/TMBarView.swift
@@ -206,6 +206,15 @@ open class TMBarView<Layout: TMBarLayout, Button: TMBarButton, Indicator: TMBarI
         }
     }
     
+    open override func didMoveToWindow() {
+        super.didMoveToWindow()
+        
+        UIView.performWithoutAnimation {
+            reloadIndicatorPosition()
+            updateEdgeFades(for: scrollView)
+        }
+    }
+    
     private func layout(in view: UIView) {
         layoutRootViews(in: view)
         


### PR DESCRIPTION
Fixes an issue that would cause the initial bar indicator to be in the wrong position when using `semanticContentAttribute` to force a RTL language layout.

![tabman](https://user-images.githubusercontent.com/3515448/80281043-ba1a5f00-8708-11ea-8d31-c91c4457d4dd.png)

Fixes #443 