### PR TITLE
Fix usage example in README.md so that it compiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ extension TabViewController: PageboyViewControllerDataSource, TMBarDataSource {
         return nil
     }
 
-    func barItem(for tabViewController: TabmanViewController, at index: Int) -> TMBarItemable {
+    func barItem(for bar: TMBar, at index: Int) -> TMBarItemable {
         let title = "Page \(index)"
         return TMBarItem(title: title)
     }


### PR DESCRIPTION
Usage section example was not compiling because `TabViewController` was not conforming to `TMBarDataSource` protocol.