### PR TITLE
Make TabmanViewController.delegate unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 `Tabman` adheres to [Semantic Versioning](http://semver.org/).
 
+#### 3.x Releases
+- `3.0.x` Releases - [3.0.0](#300)
+
 #### 2.x Releases
 - `2.9.x` Releases - [2.9.0](#290) | [2.9.1](#291)
 - `2.8.x` Releases - [2.8.0](#280) | [2.8.1](#281) | [2.8.2](#282)
@@ -33,6 +36,13 @@ All notable changes to this project will be documented in this file.
 - `0.6.x` Releases - [0.6.0](#060) | [0.6.1](#061) | [0.6.2](#062)
 - `0.5.x` Releases - [0.5.0](#050) | [0.5.1](#051) | [0.5.2](#052) | [0.5.3](#053)
 - `0.4.x` Releases - [0.4.0](#040) | [0.4.1](#041) | [0.4.2](#042) | [0.4.3](#043) | [0.4.4](#044) | [0.4.5](#045) | [0.4.6](#046) | [0.4.7](#047) | [0.4.8](#048)
+
+---
+## [3.0.0](https://github.com/uias/Tabman/releases/tag/3.0.0)
+Released on TBD
+
+#### Updated
+- `delegate` is now `unavailable` on `TabmanViewController`.
 
 ---
 ## [2.9.1](https://github.com/uias/Tabman/releases/tag/2.9.1)

--- a/Docs/Tabman 3 Migration Guide.md
+++ b/Docs/Tabman 3 Migration Guide.md
@@ -1,0 +1,17 @@
+# Tabman 3 Migration Guide
+
+This document outlines the various changes required to migrate to Tabman 3 from a previous version of Tabman.
+
+Tabman 3 is the latest major release of Tabman; A powerful paging view controller with tab bar for iOS. Tabman 3 introduces several API-breaking changes that should be made aware of.
+
+## Requirements
+- iOS 11
+- Xcode 12
+- Swift 5
+
+## What's new
+
+TODO
+
+## API Changes
+- `TabmanViewController.delegate` is now `unavailable` and can not be used.

--- a/Sources/Tabman/TabmanViewController.swift
+++ b/Sources/Tabman/TabmanViewController.swift
@@ -71,20 +71,25 @@ open class TabmanViewController: PageboyViewController, PageboyViewControllerDel
     private var barLayoutGuideTop: NSLayoutConstraint?
     private var barLayoutGuideBottom: NSLayoutConstraint?
     
+    @available(*, unavailable)
+    open override var delegate: PageboyViewControllerDelegate? {
+        didSet {}
+    }
+    
     // MARK: Init
     
     public override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
-        initialize()
+        commonInit()
     }
     
     public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-        initialize()
+        commonInit()
     }
     
-    private func initialize() {
-        delegate = self
+    private func commonInit() {
+        super.delegate = self
     }
     
     // MARK: Lifecycle


### PR DESCRIPTION
Mark `TabmanViewController.delegate` as `unavailable` to prevent misuse.

Resolves #539 