### PR TITLE
Add support for Dynamic Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ All notable changes to this project will be documented in this file.
 - `0.4.x` Releases - [0.4.0](#040) | [0.4.1](#041) | [0.4.2](#042) | [0.4.3](#043) | [0.4.4](#044) | [0.4.5](#045) | [0.4.6](#046) | [0.4.7](#047) | [0.4.8](#048)
 
 ---
+## [2.11.0](https://github.com/uias/Tabman/releases/tag/2.11.0)
+Released on 2021-03-XX
+
+#### Added
+- Support for Dynamic Type to `TMLabelBarButton` with `adjustsFontForContentSizeCategory`.
+- Support for Dynamic Type to `TMTabItemBarButton` with `adjustsFontForContentSizeCategory`.
+
+---
 ## [2.10.0](https://github.com/uias/Tabman/releases/tag/2.10.0)
 Released on 2021-01-23
 

--- a/Sources/Tabman/Bar/BarButton/Types/TMLabelBarButton.swift
+++ b/Sources/Tabman/Bar/BarButton/Types/TMLabelBarButton.swift
@@ -107,7 +107,7 @@ open class TMLabelBarButton: TMBarButton {
     /// A Boolean that indicates whether the object automatically updates its font when the device's content size category changes.
     ///
     /// Defaults to `false`.
-    @available(iOS 10, *)
+    @available(iOS 11, *)
     open var adjustsFontForContentSizeCategory: Bool {
         get {
             label.adjustsFontForContentSizeCategory

--- a/Sources/Tabman/Bar/BarButton/Types/TMLabelBarButton.swift
+++ b/Sources/Tabman/Bar/BarButton/Types/TMLabelBarButton.swift
@@ -104,6 +104,18 @@ open class TMLabelBarButton: TMBarButton {
             label.font = selectedFont
         }
     }
+    /// A Boolean that indicates whether the object automatically updates its font when the device's content size category changes.
+    ///
+    /// Defaults to `false`.
+    @available(iOS 10, *)
+    open var adjustsFontForContentSizeCategory: Bool {
+        get {
+            label.adjustsFontForContentSizeCategory
+        }
+        set {
+            label.adjustsFontForContentSizeCategory = newValue
+        }
+    }
     
     /// How to vertically align the label within the button. Defaults to `.center`.
     ///

--- a/Sources/Tabman/Bar/BarButton/Types/TMLabelBarButton.swift
+++ b/Sources/Tabman/Bar/BarButton/Types/TMLabelBarButton.swift
@@ -17,7 +17,7 @@ open class TMLabelBarButton: TMBarButton {
     
     private struct Defaults {
         static let contentInset = UIEdgeInsets(top: 12.0, left: 0.0, bottom: 12.0, right: 0.0)
-        static let font = UIFont.systemFont(ofSize: 17.0, weight: .semibold)
+        static let font = UIFont.preferredFont(forTextStyle: .headline)
         static let text = "Item"
         static let badgeLeadingInset: CGFloat = 8.0
     }

--- a/Sources/Tabman/Bar/BarButton/Types/TMTabItemBarButton.swift
+++ b/Sources/Tabman/Bar/BarButton/Types/TMTabItemBarButton.swift
@@ -302,9 +302,9 @@ extension TMTabItemBarButton {
     private func defaultFont(for device: UIDevice) -> UIFont {
         switch device.userInterfaceIdiom {
         case .pad:
-            return UIFont.systemFont(ofSize: 14.0, weight: .medium)
+            return UIFont.preferredFont(forTextStyle: .caption1)
         default:
-            return UIFont.systemFont(ofSize: 10.0, weight: .medium)
+            return UIFont.preferredFont(forTextStyle: .caption2)
         }
     }
 }

--- a/Sources/Tabman/Bar/BarButton/Types/TMTabItemBarButton.swift
+++ b/Sources/Tabman/Bar/BarButton/Types/TMTabItemBarButton.swift
@@ -277,13 +277,17 @@ open class TMTabItemBarButton: TMBarButton {
             ])
         
         // Label / Image
+        let labelTrailing = container.trailingAnchor.constraint(equalTo: label.trailingAnchor, constant: labelPadding)
+        labelTrailing.priority = .init(999)
+        let imageViewLeading = imageView.leadingAnchor.constraint(greaterThanOrEqualTo: container.leadingAnchor, constant: imagePadding)
+        imageViewLeading.priority = .init(999)
         constraints.append(contentsOf: [
             imageView.topAnchor.constraint(equalTo: container.topAnchor, constant: imagePadding),
             imageView.centerXAnchor.constraint(equalTo: container.centerXAnchor),
-            imageView.leadingAnchor.constraint(greaterThanOrEqualTo: container.leadingAnchor, constant: imagePadding),
+            imageViewLeading,
             label.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: Defaults.labelTopPadding),
             label.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: labelPadding),
-            container.trailingAnchor.constraint(equalTo: label.trailingAnchor, constant: labelPadding),
+            labelTrailing,
             label.bottomAnchor.constraint(equalTo: container.bottomAnchor)
             ])
         

--- a/Sources/Tabman/Bar/BarButton/Types/TMTabItemBarButton.swift
+++ b/Sources/Tabman/Bar/BarButton/Types/TMTabItemBarButton.swift
@@ -69,6 +69,18 @@ open class TMTabItemBarButton: TMBarButton {
             label.font = font
         }
     }
+    /// A Boolean that indicates whether the object automatically updates its font when the device's content size category changes.
+    ///
+    /// Defaults to `false`.
+    @available(iOS 10, *)
+    open var adjustsFontForContentSizeCategory: Bool {
+        get {
+            label.adjustsFontForContentSizeCategory
+        }
+        set {
+            label.adjustsFontForContentSizeCategory = newValue
+        }
+    }
     /// Content Mode for the image view.
     open var imageContentMode: UIView.ContentMode {
         get {
@@ -92,7 +104,7 @@ open class TMTabItemBarButton: TMBarButton {
         }
     }
     
-    // MARK: Lifecycle
+    // MARK: Init
 
     public required init(for item: TMBarItemable, intrinsicSuperview: UIView?) {
         super.init(for: item, intrinsicSuperview: intrinsicSuperview)
@@ -105,6 +117,8 @@ open class TMTabItemBarButton: TMBarButton {
     public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
+    
+    // MARK: Lifecycle
     
     open override func layout(in view: UIView) {
         super.layout(in: view)

--- a/Sources/Tabman/Bar/BarButton/Types/TMTabItemBarButton.swift
+++ b/Sources/Tabman/Bar/BarButton/Types/TMTabItemBarButton.swift
@@ -72,7 +72,7 @@ open class TMTabItemBarButton: TMBarButton {
     /// A Boolean that indicates whether the object automatically updates its font when the device's content size category changes.
     ///
     /// Defaults to `false`.
-    @available(iOS 10, *)
+    @available(iOS 11, *)
     open var adjustsFontForContentSizeCategory: Bool {
         get {
             label.adjustsFontForContentSizeCategory

--- a/Sources/Tabman/Bar/Generic/AnimateableLabel.swift
+++ b/Sources/Tabman/Bar/Generic/AnimateableLabel.swift
@@ -52,7 +52,7 @@ internal class AnimateableLabel: UIView {
     /// A Boolean that indicates whether the object automatically updates its font when the device's content size category changes.
     ///
     /// Defaults to `false`.
-    @available(iOS 10, *)
+    @available(iOS 11, *)
     var adjustsFontForContentSizeCategory: Bool {
         get {
             _adjustsFontForContentSizeCategory

--- a/Sources/Tabman/Bar/Generic/AnimateableLabel.swift
+++ b/Sources/Tabman/Bar/Generic/AnimateableLabel.swift
@@ -56,21 +56,22 @@ internal class AnimateableLabel: UIView {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        initialize()
+        commonInit()
     }
     
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-        initialize()
+        commonInit()
     }
     
-    private func initialize() {
+    private func commonInit() {
         
         textLayer.truncationMode = .end
         textLayer.contentsScale = UIScreen.main.scale
         layer.addSublayer(textLayer)
     }
     
+    // MARK: Lifecycle
     override func layoutSubviews() {
         super.layoutSubviews()
         

--- a/Sources/iOS/TabViewController.swift
+++ b/Sources/iOS/TabViewController.swift
@@ -45,7 +45,6 @@ class TabViewController: TabmanViewController, PageboyViewControllerDataSource, 
         bar.buttons.customize {
             $0.tintColor = UIColor.tabmanForeground.withAlphaComponent(0.4)
             $0.selectedTintColor = .tabmanForeground
-            $0.font = UIFont.preferredFont(forTextStyle: .headline)
             if #available(iOS 11, *) {
                 $0.adjustsFontForContentSizeCategory = true
             }

--- a/Sources/iOS/TabViewController.swift
+++ b/Sources/iOS/TabViewController.swift
@@ -46,7 +46,7 @@ class TabViewController: TabmanViewController, PageboyViewControllerDataSource, 
             $0.tintColor = UIColor.tabmanForeground.withAlphaComponent(0.4)
             $0.selectedTintColor = .tabmanForeground
             $0.font = UIFont.preferredFont(forTextStyle: .headline)
-            if #available(iOS 10, *) {
+            if #available(iOS 11, *) {
                 $0.adjustsFontForContentSizeCategory = true
             }
         }

--- a/Sources/iOS/TabViewController.swift
+++ b/Sources/iOS/TabViewController.swift
@@ -45,6 +45,10 @@ class TabViewController: TabmanViewController, PageboyViewControllerDataSource, 
         bar.buttons.customize {
             $0.tintColor = UIColor.tabmanForeground.withAlphaComponent(0.4)
             $0.selectedTintColor = .tabmanForeground
+            $0.font = UIFont.preferredFont(forTextStyle: .headline)
+            if #available(iOS 10, *) {
+                $0.adjustsFontForContentSizeCategory = true
+            }
         }
         bar.indicator.tintColor = .tabmanForeground
         


### PR DESCRIPTION
Adds support for Dynamic Type to the built-in bar components, specifically `TMLabelBarButton` and `TMTabItemBarButton`.

Following the `UIKit` standards, this is disabled by default and can be enabled with setting `adjustsFontForContentSizeCategory = true` and using a `UIFont` with an appropriate text style.

https://user-images.githubusercontent.com/3515448/110304616-17a35b80-7ffc-11eb-882d-7baf3a598a4a.mov

Resolves #557  