### PR TITLE
Wrong separator width in TMConstrainedHorizontalBarLayout (#563)

### DIFF
--- a/Sources/Tabman/Bar/BarLayout/Types/TMConstrainedHorizontalBarLayout.swift
+++ b/Sources/Tabman/Bar/BarLayout/Types/TMConstrainedHorizontalBarLayout.swift
@@ -75,10 +75,13 @@ private extension TMConstrainedHorizontalBarLayout {
         }
         
         var constraints = [NSLayoutConstraint]()
-        let multiplier = 1.0 / CGFloat(min(maximumCount, views.count))
-        for view in views {
+        let itemViews = views.filter { !($0 is SeparatorView) }
+        let multiplier = 1.0 / CGFloat(min(maximumCount, itemViews.count))
+        let separatorWidth = self.separatorWidth ?? 0
+        for view in itemViews {
             constraints.append(view.widthAnchor.constraint(equalTo: layoutGuide.widthAnchor,
-                                                           multiplier: multiplier))
+                                                           multiplier: multiplier,
+                                                           constant: -separatorWidth))
         }
         NSLayoutConstraint.activate(constraints)
         self.viewWidthConstraints = constraints


### PR DESCRIPTION
fixes #563 

Attached screen can be obtained with:

```swift
// Create a bar
        let bar = TMBarView.TabBar()
        
        // Customize bar properties including layout and other styling.
        bar.layout.contentInset = UIEdgeInsets(top: 0.0, left: 16.0, bottom: 4.0, right: 16.0)
        bar.fadesContentEdges = true
        bar.spacing = 16.0
        bar.layout.separatorWidth = 10
        bar.layout.showSeparators = true
```

![simulator_screenshot_EC77F4DC-D51D-4F9A-B9F4-85DC86963681](https://user-images.githubusercontent.com/1691903/111869543-5b914b80-8980-11eb-8aca-0ad12209877b.png)
