### PR TITLE
Fix not setting tab selectedButton on swipe (scroll) gesture

### DIFF
--- a/Sources/Tabman/Bar/BarButton/TMBarButtonStateController.swift
+++ b/Sources/Tabman/Bar/BarButton/TMBarButtonStateController.swift
@@ -53,6 +53,12 @@ internal final class TMBarButtonStateController: TMBarButtonController {
         }
         
         targetButton?.selectionState = .from(rawValue: directionalProgress)
-        oldTargetButton?.selectionState = .from(rawValue: 1.0 - directionalProgress)
+        
+        let progressComplement = 1.0 - directionalProgress
+                if progressComplement < 0.001 { // e - 0.001
+                    self.selectedButton = targetButton
+                }
+
+        oldTargetButton?.selectionState = .from(rawValue: progressComplement)
     }
 }

--- a/Sources/Tabman/Bar/BarButton/TMBarButtonStateController.swift
+++ b/Sources/Tabman/Bar/BarButton/TMBarButtonStateController.swift
@@ -55,10 +55,10 @@ internal final class TMBarButtonStateController: TMBarButtonController {
         targetButton?.selectionState = .from(rawValue: directionalProgress)
         
         let progressComplement = 1.0 - directionalProgress
-                if progressComplement < 0.001 { // e - 0.001
-                    self.selectedButton = targetButton
-                }
-
+        if progressComplement < 0.001 { // e - 0.001
+            self.selectedButton = targetButton
+        }
+        
         oldTargetButton?.selectionState = .from(rawValue: progressComplement)
     }
 }


### PR DESCRIPTION
_Description_
Due to progress nature of swipe scroll and animation of it, Tabman lacks saving selectedButton in TMBarView, which was set by swipe gesture.

I also could have used check on TMBarButton.SelectionState.selected, but the value of progress never reaches 1, so I'm checking for specific e - 0.001.  


_STR:_
- Go to Home Tab
- Swipe to the next tab
- Tap the next tab

_AR:_
- current and the previous tabs are highlighted

_ER:_
- only the active tab is highlighted

If you have some suggestions/comments - feel free to contact us. 
