### PR TITLE
Fix issue that textColor of AnimateableLabel refers incorrect userInterfaceStyle

### DIFF
--- a/Sources/Tabman/Bar/Extensions/UIColor+Interpolation.swift
+++ b/Sources/Tabman/Bar/Extensions/UIColor+Interpolation.swift
@@ -21,23 +21,42 @@ internal extension UIColor {
         var greenA: CGFloat = 0.0
         var blueA: CGFloat = 0.0
         var alphaA: CGFloat = 0.0
-        guard colorA.getRed(&redA, green: &greenA, blue: &blueA, alpha: &alphaA) else {
-            return nil
-        }
         
         var redB: CGFloat = 0.0
         var greenB: CGFloat = 0.0
         var blueB: CGFloat = 0.0
         var alphaB: CGFloat = 0.0
-        guard colorB.getRed(&redB, green: &greenB, blue: &blueB, alpha: &alphaB) else {
-            return nil
+        
+        var iRed: CGFloat { CGFloat(redA + percent * (redB - redA)) }
+        var iBlue: CGFloat { CGFloat(blueA + percent * (blueB - blueA)) }
+        var iGreen: CGFloat { CGFloat(greenA + percent * (greenB - greenA)) }
+        var iAlpha: CGFloat { CGFloat(alphaA + percent * (alphaB - alphaA)) }
+        var interpolatedColor: UIColor { UIColor(red: iRed, green: iGreen, blue: iBlue, alpha: iAlpha) }
+        
+        if #available(iOS 13, *) {
+            return UIColor(dynamicProvider: { traitCollection in
+                traitCollection.performAsCurrent {
+                    guard colorA.getRed(&redA, green: &greenA, blue: &blueA, alpha: &alphaA) else {
+                        return
+                    }
+                    
+                    guard colorB.getRed(&redB, green: &greenB, blue: &blueB, alpha: &alphaB) else {
+                        return
+                    }
+                }
+                
+                return interpolatedColor
+            })
+        } else {
+            guard colorA.getRed(&redA, green: &greenA, blue: &blueA, alpha: &alphaA) else {
+                return nil
+            }
+            
+            guard colorB.getRed(&redB, green: &greenB, blue: &blueB, alpha: &alphaB) else {
+                return nil
+            }
+            
+            return interpolatedColor
         }
-        
-        let iRed = CGFloat(redA + percent * (redB - redA))
-        let iBlue = CGFloat(blueA + percent * (blueB - blueA))
-        let iGreen = CGFloat(greenA + percent * (greenB - greenA))
-        let iAlpha = CGFloat(alphaA + percent * (alphaB - alphaA))
-        
-        return UIColor(red: iRed, green: iGreen, blue: iBlue, alpha: iAlpha)
     }
 }

--- a/Sources/Tabman/Bar/Extensions/UIColor+Interpolation.swift
+++ b/Sources/Tabman/Bar/Extensions/UIColor+Interpolation.swift
@@ -17,46 +17,57 @@ internal extension UIColor {
     static func interpolate(betweenColor colorA: UIColor,
                             and colorB: UIColor,
                             percent: CGFloat) -> UIColor? {
-        var redA: CGFloat = 0.0
-        var greenA: CGFloat = 0.0
-        var blueA: CGFloat = 0.0
-        var alphaA: CGFloat = 0.0
-        
-        var redB: CGFloat = 0.0
-        var greenB: CGFloat = 0.0
-        var blueB: CGFloat = 0.0
-        var alphaB: CGFloat = 0.0
-        
-        var iRed: CGFloat { CGFloat(redA + percent * (redB - redA)) }
-        var iBlue: CGFloat { CGFloat(blueA + percent * (blueB - blueA)) }
-        var iGreen: CGFloat { CGFloat(greenA + percent * (greenB - greenA)) }
-        var iAlpha: CGFloat { CGFloat(alphaA + percent * (alphaB - alphaA)) }
-        var interpolatedColor: UIColor { UIColor(red: iRed, green: iGreen, blue: iBlue, alpha: iAlpha) }
-        
         if #available(iOS 13, *) {
             return UIColor(dynamicProvider: { traitCollection in
+                var redA: CGFloat = 0.0
+                var greenA: CGFloat = 0.0
+                var blueA: CGFloat = 0.0
+                var alphaA: CGFloat = 0.0
+                
+                var redB: CGFloat = 0.0
+                var greenB: CGFloat = 0.0
+                var blueB: CGFloat = 0.0
+                var alphaB: CGFloat = 0.0
+                
                 traitCollection.performAsCurrent {
                     guard colorA.getRed(&redA, green: &greenA, blue: &blueA, alpha: &alphaA) else {
                         return
                     }
-                    
                     guard colorB.getRed(&redB, green: &greenB, blue: &blueB, alpha: &alphaB) else {
                         return
                     }
                 }
                 
-                return interpolatedColor
+                let iRed = CGFloat(redA + percent * (redB - redA))
+                let iBlue = CGFloat(blueA + percent * (blueB - blueA))
+                let iGreen = CGFloat(greenA + percent * (greenB - greenA))
+                let iAlpha = CGFloat(alphaA + percent * (alphaB - alphaA))
+                
+                return UIColor(red: iRed, green: iGreen, blue: iBlue, alpha: iAlpha)
             })
         } else {
+            var redA: CGFloat = 0.0
+            var greenA: CGFloat = 0.0
+            var blueA: CGFloat = 0.0
+            var alphaA: CGFloat = 0.0
             guard colorA.getRed(&redA, green: &greenA, blue: &blueA, alpha: &alphaA) else {
                 return nil
             }
             
+            var redB: CGFloat = 0.0
+            var greenB: CGFloat = 0.0
+            var blueB: CGFloat = 0.0
+            var alphaB: CGFloat = 0.0
             guard colorB.getRed(&redB, green: &greenB, blue: &blueB, alpha: &alphaB) else {
                 return nil
             }
             
-            return interpolatedColor
+            let iRed = CGFloat(redA + percent * (redB - redA))
+            let iBlue = CGFloat(blueA + percent * (blueB - blueA))
+            let iGreen = CGFloat(greenA + percent * (greenB - greenA))
+            let iAlpha = CGFloat(alphaA + percent * (alphaB - alphaA))
+            
+            return UIColor(red: iRed, green: iGreen, blue: iBlue, alpha: iAlpha)
         }
     }
 }

--- a/Sources/Tabman/Bar/Generic/AnimateableLabel.swift
+++ b/Sources/Tabman/Bar/Generic/AnimateableLabel.swift
@@ -34,7 +34,11 @@ internal class AnimateableLabel: UIView {
         }
         set {
             let textColor = newValue ?? .black
-            textLayer.foregroundColor = textColor.cgColor
+            if #available(iOS 13, *) {
+                textLayer.foregroundColor = textColor.resolvedColor(with: traitCollection).cgColor
+            } else {
+                textLayer.foregroundColor = textColor.cgColor
+            }
         }
     }
     var font: UIFont? {


### PR DESCRIPTION

https://user-images.githubusercontent.com/54972653/176935119-4877abfb-4748-4ef5-a61e-bd42dd00a79d.mov

When viewController overrides userInterfaceStyle as .light and contains AnimateableLabel as subview, it refers wrong traitCollection and shows wrong text color. In this case, AnimateableLabel refers .dark which is system setting of my simulator.

Therefore I modified two codes.
1. UIColor.interpolate() returns dynamicColor on iOS 13 and higher
2. AnimateableLabel's textColor refers AnimateableLabel's traitCollection

https://user-images.githubusercontent.com/54972653/176937630-298d6b44-deeb-4a95-b289-5e45e9cde3f4.mov

Now it works well.

Please consider it. 
Thank you 😄 
