### PR TITLE
Fix `TMBarBackgroundView` not being constrained correctly

### DIFF
--- a/Sources/Tabman/Bar/BarView/TMBarView.swift
+++ b/Sources/Tabman/Bar/BarView/TMBarView.swift
@@ -246,21 +246,23 @@ open class TMBarView<Layout: TMBarLayout, Button: TMBarButton, Indicator: TMBarI
         constraints.append(contentsOf: [
             backgroundView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             backgroundView.topAnchor.constraint(equalTo: view.topAnchor),
-            backgroundView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            backgroundView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+            view.trailingAnchor.constraint(equalTo: backgroundView.trailingAnchor),
+            view.bottomAnchor.constraint(equalTo: backgroundView.bottomAnchor)
             ])
         
         rootContentStack.axis = .horizontal
         view.addSubview(rootContentStack)
         rootContentStack.translatesAutoresizingMaskIntoConstraints = false
-        self.rootContainerTop = rootContentStack.topAnchor.constraint(equalTo: view.topAnchor)
-        self.rootContainerBottom = view.bottomAnchor.constraint(equalTo: rootContentStack.bottomAnchor)
-        NSLayoutConstraint.activate([
+        rootContainerTop = rootContentStack.topAnchor.constraint(equalTo: view.topAnchor)
+        rootContainerBottom = view.bottomAnchor.constraint(equalTo: rootContentStack.bottomAnchor)
+        constraints.append(contentsOf: [
             rootContentStack.leadingAnchor.constraint(equalTo: view.safeAreaLeadingAnchor),
             rootContainerTop,
             rootContentStack.trailingAnchor.constraint(equalTo: view.safeAreaTrailingAnchor),
             rootContainerBottom
         ])
+
+        NSLayoutConstraint.activate(constraints)
     }
 
     private func updateScrollViewContentInset() {

--- a/Sources/Tabman/Bar/Generic/AnimateableLabel.swift
+++ b/Sources/Tabman/Bar/Generic/AnimateableLabel.swift
@@ -96,16 +96,14 @@ internal class AnimateableLabel: UIView {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         
-        if #available(iOS 10, *) {
-            guard traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory else {
-                return
-            }
-            reloadTextLayerForCurrentFont()
+        guard traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory else {
+            return
         }
+        reloadTextLayerForCurrentFont()
     }
     
     private func reloadTextLayerForCurrentFont() {
-        if #available(iOS 11, *), adjustsFontForContentSizeCategory, let font = font, let textStyle = font.fontDescriptor.object(forKey: .textStyle) as? UIFont.TextStyle {
+        if adjustsFontForContentSizeCategory, let font = font, let textStyle = font.fontDescriptor.object(forKey: .textStyle) as? UIFont.TextStyle {
             let font = UIFontMetrics(forTextStyle: textStyle).scaledFont(for: font)
             textLayer.font = font
             textLayer.fontSize = font.pointSize

--- a/Sources/iOS/ButtonBarExampleViewController.swift
+++ b/Sources/iOS/ButtonBarExampleViewController.swift
@@ -45,9 +45,7 @@ class ButtonBarExampleViewController: TabmanViewController, PageboyViewControlle
         bar.buttons.customize {
             $0.tintColor = UIColor.tabmanForeground.withAlphaComponent(0.4)
             $0.selectedTintColor = .tabmanForeground
-            if #available(iOS 11, *) {
-                $0.adjustsFontForContentSizeCategory = true
-            }
+            $0.adjustsFontForContentSizeCategory = true
         }
         bar.indicator.tintColor = .tabmanForeground
         

--- a/Sources/iOS/TabItemBarExampleViewController.swift
+++ b/Sources/iOS/TabItemBarExampleViewController.swift
@@ -41,9 +41,7 @@ class TabItemBarExampleViewController: TabmanViewController, PageboyViewControll
         bar.buttons.customize {
             $0.tintColor = UIColor.tabmanForeground.withAlphaComponent(0.4)
             $0.selectedTintColor = .tabmanForeground
-            if #available(iOS 11, *) {
-                $0.adjustsFontForContentSizeCategory = true
-            }
+            $0.adjustsFontForContentSizeCategory = true
         }
         bar.indicator.tintColor = .tabmanForeground
         
@@ -77,7 +75,7 @@ class TabItemBarExampleViewController: TabmanViewController, PageboyViewControll
 extension UIImage {
     
     class var star: UIImage? {
-        if #available(iOS 13.0, *) {
+        if #available(iOS 13, *) {
             return UIImage(systemName: "star")
         } else {
             return nil
@@ -85,7 +83,7 @@ extension UIImage {
     }
     
     class var starFilled: UIImage? {
-        if #available(iOS 13.0, *) {
+        if #available(iOS 13, *) {
             return UIImage(systemName: "star.fill")
         } else {
             return nil


### PR DESCRIPTION
Fixes an issue where `TMBarView.backgroundView` was no longer having its constraints activated, inadvertently caused by #546 

Resolves #605 