### PR TITLE
Fix set badge tint color

### DIFF
--- a/Sources/Tabman/Bar/BarButton/Badge/TMBadgeView.swift
+++ b/Sources/Tabman/Bar/BarButton/Badge/TMBadgeView.swift
@@ -66,11 +66,8 @@ open class TMBadgeView: UIView {
             label.textColor = newValue
         }
     }
-    /// Tint which is used as background color.
-    open override var tintColor: UIColor! {
-        didSet {
-            contentView.backgroundColor = tintColor
-        }
+    open override func tintColorDidChange() {
+        contentView.backgroundColor = tintColor
     }
     /// Content Inset around the badge label.
     ///


### PR DESCRIPTION
Given a button badge is behind a modally presented view controller, when the tint color of the badge is set, then the badge color will be gray instead of the set color.

One way to fix this is to utilise `tintColorDidChange` instead of using a `didSet` for `tintColor`.

In these before and after examples, the badge tint color is being set to red in `onTraitCollectionDidChange`, which is being triggered by changing from dark to light mode (or vice versa):

Before:
https://user-images.githubusercontent.com/34710656/231182379-da87b0af-b8f8-4048-876f-8ef460340db1.mp4

After:
https://user-images.githubusercontent.com/34710656/231180867-72d0c09b-6c32-43d4-a256-450c3a7b745b.mp4

The downside to this fix is that the doc comment is removed. Another fix would be to use a new `var` instead of overriding `tintColor`, but that would create breaking changes.