### PR TITLE
Added barViewDidScroll (open) method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ fastlane/test_output
 # IntelliJ
 
 .idea/
+.DS_Store

--- a/Sources/Tabman/Bar/BarView/TMBarView.swift
+++ b/Sources/Tabman/Bar/BarView/TMBarView.swift
@@ -345,6 +345,10 @@ open class TMBarView<Layout: TMBarLayout, Button: TMBarButton, Indicator: TMBarI
         }
         return allAccessibilityElements.firstIndex(where: { $0 === item }) ?? 0
     }
+
+    open func barViewDidScroll(scrollView: UIScrollView) {
+        updateEdgeFades(for: scrollView)
+    }
 }
 
 // MARK: - Bar
@@ -595,6 +599,6 @@ extension TMBarView: TMBarViewScrollHandlerDelegate {
                               didReceiveUpdated contentOffset: CGPoint,
                               from scrollView: UIScrollView) {
         
-        updateEdgeFades(for: scrollView)
+        barViewDidScroll(scrollView: scrollView)
     }
 }


### PR DESCRIPTION
### Background Context:
Thanks for creating and maintaining this awesome library We are using `TabMan` in our project, recently we added a functionality where we will do some action when user will scroll the tab bar view horizontally. We checked the library and found that, all the listener are marked internal / private. As a result we can not detect didScroll of tabBarView.

In this PR, I have added an `open` method called `barViewDidScroll` which can be overridden from outside of this module to detect the horizontal scrolling of tabBarView. I hope that, you will review the PR.
